### PR TITLE
Bump version to 0.0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kindergarden"
-version = "0.0.9"
+version = "0.0.10"
 description = "A robotics benchmark for physical reasoning."
 license = {text = "MIT"}
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump version to 0.0.10 to include NoisyObservation/NoisyAction wrappers in a release. This is needed to pass the pylint and mypy checks for the baseline experiment code.

## Changes since v0.0.9
- Add NoisyObservation and NoisyAction wrappers (#42)
- Clip noisy observations to observation space bounds (#43)
- Fix corrupted demos (#39)