### PR TITLE
Ensure stable reset

### DIFF
--- a/src/kinder/envs/dynamic3d/tidybot3d.py
+++ b/src/kinder/envs/dynamic3d/tidybot3d.py
@@ -823,6 +823,10 @@ class ObjectCentricRobotEnv(ObjectCentricDynamic3DRobotEnv[TidyBot3DConfig]):
         # Initialize the robot pose
         self._initialize_robot_pose()
 
+        # step several times to get the initial state
+        for _ in range(10):
+            self._robot_env.step(np.zeros(TidyBot3DRobotActionSpace().shape))
+
         # Get object-centric observation
         self._current_state = self._get_object_centric_state()
 


### PR DESCRIPTION
Added several env.step() during reset() function to ensure that the objects will be stable on the ground or on the table. This can ensure that the downstream controllers get a stable object pose. 