### PR TITLE
bump to version 0.0.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kindergarden"
-version = "0.0.10"
+version = "0.0.11"
 description = "A robotics benchmark for physical reasoning."
 license = {text = "MIT"}
 readme = "README.md"


### PR DESCRIPTION
## Summary 
- This is to pass the unit tests in kinder-models and kinder-bilevel-planning due to the changes in env.reset() in dynamics3d environments. 

## Changes since v0.0.10
- remove old trajopt notebook (#51)
- Ensure stable reset (#54)
- Rename tidybot3d.py to envs.py (#58)