### PR TITLE
Auto-download mimiclabs scenes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI Checks
 
+env:
+  DISABLE_AUTO_DYNAMIC3D_SCENES_DOWNLOAD: "1"
+
 on:
   push:
     branches: [main]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+__MACOSX/
 .python-version
 MUJOCO_LOG.TXT
 **/auto_*.xml

--- a/run_ci_checks.sh
+++ b/run_ci_checks.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export DISABLE_AUTO_DYNAMIC3D_SCENES_DOWNLOAD=1
+
 ./run_autoformat.sh
 mypy .
 pytest . --pylint -m pylint --pylint-rcfile=.pylintrc --ignore=notebooks

--- a/scripts/download_mimiclabs_assets.py
+++ b/scripts/download_mimiclabs_assets.py
@@ -27,13 +27,19 @@ ASSETS_URL = (
 )
 
 
-def download_file_from_gdrive(url: str, download_dir: Path, dst_filename: str) -> None:
+def download_file_from_gdrive(
+    url: str,
+    download_dir: Path,
+    dst_filename: str,
+    non_interactive: bool = False,
+) -> None:
     """Download a file from Google Drive using gdown.
 
     Args:
         url: Google Drive sharing URL
         download_dir: Directory to download to
         dst_filename: Destination filename
+        non_interactive: If True, avoid prompts and overwrite existing files
     """
     tmp_dir = download_dir / "tmp"
     tmp_dir.mkdir(exist_ok=True, parents=True)
@@ -52,14 +58,19 @@ def download_file_from_gdrive(url: str, download_dir: Path, dst_filename: str) -
     # Move downloaded file to destination
     dst_path = download_dir / dst_filename
     if dst_path.exists():
-        inp = input(
-            f"File {dst_path} already exists. Would you like to overwrite it? y/n\n"
-        )
-        if inp.lower() in ["y", "yes"]:
+        if non_interactive:
+            os.remove(dst_path)
             shutil.move(str(tmp_path), str(dst_path))
             print(f"Overwritten {dst_path}")
         else:
-            print(f"File {dst_path} not overwritten.")
+            inp = input(
+                f"File {dst_path} already exists. Would you like to overwrite it? y/n\n"
+            )
+            if inp.lower() in ["y", "yes"]:
+                shutil.move(str(tmp_path), str(dst_path))
+                print(f"Overwritten {dst_path}")
+            else:
+                print(f"File {dst_path} not overwritten.")
     else:
         shutil.move(str(tmp_path), str(dst_path))
         print(f"Downloaded to {dst_path}")
@@ -69,19 +80,25 @@ def download_file_from_gdrive(url: str, download_dir: Path, dst_filename: str) -
         shutil.rmtree(tmp_dir)
 
 
-def download_mimiclabs_assets() -> None:
+def download_mimiclabs_assets(non_interactive: bool = False) -> None:
     """Download the MimicLabs scene assets from Google Drive.
 
     This will:
     1. Download assets.zip from Google Drive
     2. Extract it to kinder/src/kinder/envs/dynamic3d/models/assets/mimiclabs_scenes/
     3. Clean up the zip file
+
+    Args:
+        non_interactive: If True, avoid prompts and keep existing scene directory.
     """
     # Ensure assets directory exists
     ASSETS_DIR.mkdir(exist_ok=True, parents=True)
 
     # Check if mimiclabs_scenes already exists
     if MIMICLABS_SCENES_DIR.exists():
+        if non_interactive:
+            print(f"MimicLabs scenes already exist at {MIMICLABS_SCENES_DIR}")
+            return
         print(f"\nWarning: Directory {MIMICLABS_SCENES_DIR} already exists.")
         inp = input("Would you like to remove it and re-download? y/n\n")
         if inp.lower() in ["y", "yes"]:
@@ -96,7 +113,12 @@ def download_mimiclabs_assets() -> None:
 
     # Download the assets zip file
     zip_filename = "assets.zip"
-    download_file_from_gdrive(ASSETS_URL, ASSETS_DIR, zip_filename)
+    download_file_from_gdrive(
+        ASSETS_URL,
+        ASSETS_DIR,
+        zip_filename,
+        non_interactive=non_interactive,
+    )
 
     # Unzip the assets
     zip_path = ASSETS_DIR / zip_filename

--- a/src/kinder/__init__.py
+++ b/src/kinder/__init__.py
@@ -494,7 +494,6 @@ def _register_env_class(
 def _ensure_assets_for_env(env_id: str) -> None:
     """Auto-download MimicLabs assets once, only for Dynamic3D environments."""
     dynamic3d_env_ids = {
-        # vid.removesuffix("-v0")
         vid
         for cls in get_env_categories().get("Dynamic3D", [])
         for vid in ENV_CLASSES[cls]["variants"]
@@ -510,12 +509,12 @@ def _ensure_assets_for_env(env_id: str) -> None:
         )
         return
 
-    _package_root = Path(__file__).parent
+    package_root = Path(__file__).parent
     mimiclabs_scenes_dir = (
-        _package_root / "envs" / "dynamic3d" / "models" / "assets" / "mimiclabs_scenes"
+        package_root / "envs" / "dynamic3d" / "models" / "assets" / "mimiclabs_scenes"
     )
     mimiclabs_download_script = (
-        _package_root.parent.parent / "scripts" / "download_mimiclabs_assets.py"
+        package_root.parent.parent / "scripts" / "download_mimiclabs_assets.py"
     )
 
     # If assets are already present, skip download.
@@ -525,11 +524,10 @@ def _ensure_assets_for_env(env_id: str) -> None:
     module_name = "kinder_mimiclabs_asset_downloader"
     spec = util.spec_from_file_location(module_name, mimiclabs_download_script)
     if spec is None or spec.loader is None:
-        warnings.warn(
+        raise FileNotFoundError(
             "MimicLabs assets are missing and auto-download could not be initialized. "
-            "Run scripts/download_mimiclabs_assets.py manually."
+            "Download mimiclabs assets manually."
         )
-        return
 
     module = util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -538,11 +536,11 @@ def _ensure_assets_for_env(env_id: str) -> None:
         print("Auto-downloading MimicLabs assets for Dynamic3D environments...")
         module.download_mimiclabs_assets(non_interactive=True)
     except Exception as err:  # pylint: disable=broad-except
-        warnings.warn(
+        raise RuntimeError(
             "Auto-download of MimicLabs assets failed. "
             "Run scripts/download_mimiclabs_assets.py manually. "
             f"Error: {err}"
-        )
+        ) from err
 
 
 def make(*args, **kwargs) -> gymnasium.Env:

--- a/src/kinder/__init__.py
+++ b/src/kinder/__init__.py
@@ -533,7 +533,10 @@ def _ensure_assets_for_env(env_id: str) -> None:
     spec.loader.exec_module(module)
 
     try:
-        print("Auto-downloading MimicLabs assets for Dynamic3D environments...")
+        print(
+            "Auto-downloading MimicLabs assets for Dynamic3D environments "
+            "(this may take a few minutes)..."
+        )
         module.download_mimiclabs_assets(non_interactive=True)
     except Exception as err:  # pylint: disable=broad-except
         raise RuntimeError(

--- a/src/kinder/__init__.py
+++ b/src/kinder/__init__.py
@@ -3,8 +3,14 @@
 import os
 import sys
 import warnings
+from importlib import util
 from pathlib import Path
 from typing import Any
+
+from kinder.macros import (  # noqa: E402  # pylint: disable=wrong-import-position
+    DISABLE_AUTO_DYNAMIC3D_SCENES_DOWNLOAD,
+    is_truthy_env_var,
+)
 
 # Silence warnings from third-party packages
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="kortex_api")
@@ -487,8 +493,67 @@ def _register_env_class(
     }
 
 
+def _ensure_assets_for_env(env_id: str) -> None:
+    """Auto-download MimicLabs assets once, only for Dynamic3D environments."""
+    dynamic3d_env_ids = {
+        # vid.removesuffix("-v0")
+        vid
+        for cls in get_env_categories().get("Dynamic3D", [])
+        for vid in ENV_CLASSES[cls]["variants"]
+    }
+    if env_id not in dynamic3d_env_ids:
+        return
+
+    if is_truthy_env_var(DISABLE_AUTO_DYNAMIC3D_SCENES_DOWNLOAD):
+        print(
+            f"Auto-download of MimicLabs assets is disabled via "
+            f"{DISABLE_AUTO_DYNAMIC3D_SCENES_DOWNLOAD} environment variable. "
+            "If you want to enable it, unset this variable or set it to a falsy value."
+        )
+        return
+
+    _package_root = Path(__file__).parent
+    mimiclabs_scenes_dir = (
+        _package_root / "envs" / "dynamic3d" / "models" / "assets" / "mimiclabs_scenes"
+    )
+    mimiclabs_download_script = (
+        _package_root.parent.parent / "scripts" / "download_mimiclabs_assets.py"
+    )
+
+    # If assets are already present, skip download.
+    if mimiclabs_scenes_dir.exists():
+        return
+
+    module_name = "kinder_mimiclabs_asset_downloader"
+    spec = util.spec_from_file_location(module_name, mimiclabs_download_script)
+    if spec is None or spec.loader is None:
+        warnings.warn(
+            "MimicLabs assets are missing and auto-download could not be initialized. "
+            "Run scripts/download_mimiclabs_assets.py manually."
+        )
+        return
+
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    try:
+        print("Auto-downloading MimicLabs assets for Dynamic3D environments...")
+        module.download_mimiclabs_assets(non_interactive=True)
+    except Exception as err:  # pylint: disable=broad-except
+        warnings.warn(
+            "Auto-download of MimicLabs assets failed. "
+            "Run scripts/download_mimiclabs_assets.py manually. "
+            f"Error: {err}"
+        )
+
+
 def make(*args, **kwargs) -> gymnasium.Env:
     """Create a registered environment from its name."""
+    env_id = kwargs.get("id")
+    if env_id is None and args:
+        env_id = args[0]
+    if isinstance(env_id, str):
+        _ensure_assets_for_env(env_id)
     return gymnasium.make(*args, **kwargs)
 
 

--- a/src/kinder/__init__.py
+++ b/src/kinder/__init__.py
@@ -7,11 +7,6 @@ from importlib import util
 from pathlib import Path
 from typing import Any
 
-from kinder.macros import (  # noqa: E402  # pylint: disable=wrong-import-position
-    DISABLE_AUTO_DYNAMIC3D_SCENES_DOWNLOAD,
-    is_truthy_env_var,
-)
-
 # Silence warnings from third-party packages
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="kortex_api")
 warnings.filterwarnings("ignore", category=UserWarning, module="phoenix6")
@@ -19,11 +14,14 @@ warnings.filterwarnings("ignore", category=DeprecationWarning, module="pkg_resou
 
 # Need to import after silencing warnings
 import gymnasium  # pylint: disable=wrong-import-position
-from gymnasium.envs.registration import (  # pylint: disable=wrong-import-position
-    register,
-)
 
-from kinder.wrappers import (  # noqa: E402  # pylint: disable=wrong-import-position,unused-import
+from gymnasium.envs.registration import register  # pylint: disable=wrong-import-position
+
+from kinder.macros import (  # pylint: disable=wrong-import-position
+    DISABLE_AUTO_DYNAMIC3D_SCENES_DOWNLOAD,
+    is_truthy_env_var,
+)
+from kinder.wrappers import (  # pylint: disable=wrong-import-position,unused-import
     NoisyAction,
     NoisyObservation,
 )

--- a/src/kinder/macros.py
+++ b/src/kinder/macros.py
@@ -1,0 +1,25 @@
+"""Macros and configuration constants for KinDER.
+
+Environment variable macros
+---------------------------
+DISABLE_AUTO_DYNAMIC3D_SCENES_DOWNLOAD
+    Set to "1", "true", "yes", or "on" to prevent kinder.make() from
+    automatically downloading MimicLabs scene assets on the first call
+    to a Dynamic3D environment.  This is set automatically during CI.
+"""
+
+import os
+
+# ---------------------------------------------------------------------------
+# MimicLabs asset download macro
+# ---------------------------------------------------------------------------
+
+# Name of the environment variable that disables automatic asset downloads.
+DISABLE_AUTO_DYNAMIC3D_SCENES_DOWNLOAD = "DISABLE_AUTO_DYNAMIC3D_SCENES_DOWNLOAD"
+
+def is_truthy_env_var(name: str) -> bool:
+    """Return True when an environment variable is set to a truthy value.
+
+    Accepted values (case-insensitive): "1", "true", "yes", "on".
+    """
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}


### PR DESCRIPTION
- Lazy download MimicLabs scene assets the first time a Dynamic3D env is created
- Created env var `DISABLE_AUTO_DYNAMIC3D_SCENES_DOWNLOAD` which can be used to disable automatic (lazy) download of dynamic3d assets
- Set `DISABLE_AUTO_DYNAMIC3D_SCENES_DOWNLOAD` to disable auto-download in CI checks

TODOs:
- [x] Test on a clean setup