### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kindergarden"
-version = "0.0.11"
+version = "0.1.0"
 description = "A robotics benchmark for physical reasoning."
 license = {text = "MIT"}
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump kindergarden version from 0.0.11 to 0.1.0 in preparation for the v0.1.0 release.

## Test plan
- [x] Local `./run_ci_checks.sh` passes
- [ ] CI passes on this PR