### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kindergarden"
-version = "0.1.2"
+version = "0.1.3"
 description = "A robotics benchmark for physical reasoning."
 license = {text = "MIT"}
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump kindergarden to 0.1.3 ahead of PyPI release
- Includes recent fixes: action-space dtype warning (#84) and Dynamic3D variant descriptions (#85)

## Test plan
- [x] CI passes