### PR TITLE
Prune runtime caches from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,6 @@ prune tests
 prune notebooks
 prune scripts
 prune pylint_plugins
+prune src/kinder/envs/dynamic3d/models/assets/mimiclabs_scenes
+prune src/kinder/envs/dynamic3d/models/assets/.tmp
+prune src/kinder/envs/dynamic3d/models/assets/__MACOSX


### PR DESCRIPTION
## Summary
- Prune `mimiclabs_scenes/`, `.tmp/`, and `__MACOSX/` from `src/kinder/envs/dynamic3d/models/assets/`. These are runtime-downloaded or runtime-generated, never source artifacts.
- Without these prunes, building from a tree that has already run any Dynamic3D env produces a >1GB sdist that PyPI rejects with a 500. With them, sdist size goes from 1.0 GB → 70 MB, matching the 0.1.2 release.

## Test plan
- [x] `uv build` from a tree with mimiclabs assets present locally → 70 MB sdist (was 1.0 GB)
- [x] `tar -tzf dist/*.tar.gz | grep -E "mimiclabs_scenes|\.tmp/|__MACOSX"` returns no matches