### PR TITLE
fixed issue81, using shapely.Polygon to check goals in Packing3D

### DIFF
--- a/src/kinder/envs/kinematic3d/packing3d.py
+++ b/src/kinder/envs/kinematic3d/packing3d.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any
+from typing import cast
 from typing import Type as TypingType
 
 import numpy as np
@@ -249,7 +250,7 @@ class Packing3DObjectCentricState(Kinematic3DObjectCentricState):
             ]
         )
         world_corners = (rot @ local_corners.T).T + pos
-        return Polygon(world_corners[:, :2]).convex_hull
+        return cast(Polygon, Polygon(world_corners[:, :2]).convex_hull)
 
     def _get_triangle_xy_polygon(self, name: str) -> Polygon:
         obj = self.get_object_from_name(name)

--- a/src/kinder/envs/kinematic3d/packing3d.py
+++ b/src/kinder/envs/kinematic3d/packing3d.py
@@ -19,6 +19,8 @@ from pybullet_helpers.utils import (
 )
 from relational_structs import Object, ObjectCentricState, Type
 from relational_structs.utils import create_state_from_dict
+from scipy.spatial.transform import Rotation
+from shapely.geometry import Polygon
 
 from kinder.core import ConstantObjectKinDEREnv, FinalConfigMeta
 from kinder.envs.kinematic3d.base_env import (
@@ -230,6 +232,64 @@ class Packing3DObjectCentricState(Kinematic3DObjectCentricState):
             self.get(obj, "depth"),
             self.get(obj, "triangle_type"),
         )
+
+    @staticmethod
+    def _get_box_xy_polygon(
+        pose: Pose,
+        half_extents: tuple[float, float, float],
+    ) -> Polygon:
+        pos = np.array(pose.position)
+        rot = Rotation.from_quat(pose.orientation).as_matrix()
+        local_corners = np.array(
+            [
+                [sx * half_extents[0], sy * half_extents[1], sz * half_extents[2]]
+                for sx in [-1, 1]
+                for sy in [-1, 1]
+                for sz in [-1, 1]
+            ]
+        )
+        world_corners = (rot @ local_corners.T).T + pos
+        return Polygon(world_corners[:, :2]).convex_hull
+
+    def _get_triangle_xy_polygon(self, name: str) -> Polygon:
+        obj = self.get_object_from_name(name)
+        position = np.array(
+            [
+                self.get(obj, "pose_x"),
+                self.get(obj, "pose_y"),
+                self.get(obj, "pose_z"),
+            ]
+        )
+        orientation = (
+            self.get(obj, "pose_qx"),
+            self.get(obj, "pose_qy"),
+            self.get(obj, "pose_qz"),
+            self.get(obj, "pose_qw"),
+        )
+        side_a, side_b, _, triangle_type = self.get_object_triangle_features(name)
+        local_vertices = np.array(
+            get_triangle_vertices(
+                {0: "equilateral", 1: "right"}[int(triangle_type)],
+                (side_a, side_b),
+            )
+        )
+        rot = Rotation.from_quat(orientation).as_matrix()
+        world_vertices = (rot @ local_vertices.T).T + position
+        return Polygon(world_vertices[:, :2])
+
+    def is_part_inside_rack(self, part_name: str) -> bool:
+        """Check whether a part's true footprint is inside the rack footprint."""
+        part = self.get_object_from_name(part_name)
+        rack_polygon = self._get_box_xy_polygon(self.rack_pose, self.rack_half_extents)
+        if part.type == Kinematic3DCuboidType:
+            part_polygon = self._get_box_xy_polygon(
+                self.get_object_pose(part_name),
+                self.get_object_half_extents_packing3d(part_name)[:3],
+            )
+        else:
+            assert part.type == Kinematic3DTriangleType
+            part_polygon = self._get_triangle_xy_polygon(part_name)
+        return rack_polygon.buffer(1e-9).contains(part_polygon)
 
     @property
     def objects(self) -> list[Object]:
@@ -725,14 +785,10 @@ class ObjectCentricPacking3DEnv(
         # Goal: no parts are grasped and all parts are supported by the rack.
         if self._grasped_object is not None:
             return False
+        obs = self._get_obs()
         for i in range(self._num_parts):
             part_name = f"part{i}"
-            if not is_inside(
-                self._get_obs().rack_pose,
-                self._get_obs().rack_half_extents,
-                self._get_obs().get_object_pose(part_name),
-                self._get_obs().get_object_half_extents_packing3d(part_name)[:3],
-            ):
+            if not obs.is_part_inside_rack(part_name):
                 return False
 
         return True

--- a/tests/envs/kinematic3d/test_packing3d.py
+++ b/tests/envs/kinematic3d/test_packing3d.py
@@ -12,15 +12,19 @@ from pybullet_helpers.motion_planning import (
     run_smooth_motion_planning_to_pose,
     smoothly_follow_end_effector_path,
 )
+from pybullet_helpers.utils import get_triangle_vertices
 from relational_structs import Object
 from relational_structs.spaces import ObjectCentricBoxSpace
+from shapely.geometry import Polygon
 
+from kinder.envs.kinematic3d.object_types import Kinematic3DTriangleType
 from kinder.envs.kinematic3d.packing3d import (
     ObjectCentricPacking3DEnv,
     Packing3DEnv,
     Packing3DObjectCentricState,
 )
 from kinder.envs.kinematic3d.save_utils import DEFAULT_DEMOS_DIR, save_demo
+from kinder.envs.kinematic3d.utils import is_inside
 from tests.conftest import MAKE_VIDEOS
 
 # Flag to enable trajectory saving (can be controlled like MAKE_VIDEOS)
@@ -43,6 +47,79 @@ def test_packing3d_env_basic():
             obs, _, _, _, _ = env.step(act)
 
         env.close()
+
+
+def test_packing3d_goal():
+    """Test the current triangle containment issue in Packing3D goal checks."""
+    env = ObjectCentricPacking3DEnv(
+        num_parts=1,
+        use_gui=False,
+        realistic_bg=False,
+        allow_state_access=True,
+    )
+    
+    obs, _ = env.reset(seed=0)
+    part = obs.get_object_from_name("part0")
+    assert part.type == Kinematic3DTriangleType
+    assert obs.get(part, "triangle_type") == 1
+
+    rack_pose = obs.rack_pose
+    rack_half_extents = obs.rack_half_extents
+    side_a, side_b, _, triangle_type = obs.get_object_triangle_features("part0")
+    assert triangle_type == 1
+
+    triangle_vertices = get_triangle_vertices("right", (side_a, side_b))
+    centroid_x = sum(v[0] for v in triangle_vertices) / 3.0
+    centroid_y = sum(v[1] for v in triangle_vertices) / 3.0
+    part_x = rack_pose.position[0] - rack_half_extents[0]
+    part_y = rack_pose.position[1] - side_b / 2
+
+    obs.set(part, "pose_x", part_x - centroid_x)
+    obs.set(part, "pose_y", part_y - centroid_y)
+    obs.set(part, "pose_z", rack_pose.position[2])
+    obs.set(part, "pose_qx", 0.0)
+    obs.set(part, "pose_qy", 0.0)
+    obs.set(part, "pose_qz", 0.0)
+    obs.set(part, "pose_qw", 1.0)
+    obs.set(part, "grasp_active", 0.0)
+    env.set_state(obs)
+
+    rack_polygon = Polygon(
+        [
+            (
+                rack_pose.position[0] - rack_half_extents[0],
+                rack_pose.position[1] - rack_half_extents[1],
+            ),
+            (
+                rack_pose.position[0] + rack_half_extents[0],
+                rack_pose.position[1] - rack_half_extents[1],
+            ),
+            (
+                rack_pose.position[0] + rack_half_extents[0],
+                rack_pose.position[1] + rack_half_extents[1],
+            ),
+            (
+                rack_pose.position[0] - rack_half_extents[0],
+                rack_pose.position[1] + rack_half_extents[1],
+            ),
+        ]
+    )
+    triangle_polygon = Polygon(
+        [(part_x + vx, part_y + vy) for vx, vy, _ in triangle_vertices]
+    )
+
+    assert rack_polygon.covers(triangle_polygon)
+
+    updated_obs = env.get_state()
+    assert not is_inside(
+        updated_obs.rack_pose,
+        updated_obs.rack_half_extents,
+        updated_obs.get_object_pose("part0"),
+        updated_obs.get_object_half_extents_packing3d("part0")[:3],
+    )
+    assert env.goal_reached()
+
+    env.close()
 
 
 def get_target_object_from_obs(
@@ -68,9 +145,9 @@ def test_pick_place_on_rack() -> None:
     )
     assert isinstance(env.observation_space, ObjectCentricBoxSpace)
     obs_space = env.observation_space
-    config = (
-        cast(Packing3DEnv, env.unwrapped)._object_centric_env.config  # pylint: disable=protected-access
-    )
+    config = cast(
+        Packing3DEnv, env.unwrapped
+    )._object_centric_env.config  # pylint: disable=protected-access
     if MAKE_VIDEOS:
         env = RecordVideo(env, "unit_test_videos")  # type: ignore[assignment]
 

--- a/tests/envs/kinematic3d/test_packing3d.py
+++ b/tests/envs/kinematic3d/test_packing3d.py
@@ -57,7 +57,7 @@ def test_packing3d_goal():
         realistic_bg=False,
         allow_state_access=True,
     )
-    
+
     obs, _ = env.reset(seed=0)
     part = obs.get_object_from_name("part0")
     assert part.type == Kinematic3DTriangleType
@@ -145,9 +145,9 @@ def test_pick_place_on_rack() -> None:
     )
     assert isinstance(env.observation_space, ObjectCentricBoxSpace)
     obs_space = env.observation_space
-    config = cast(
-        Packing3DEnv, env.unwrapped
-    )._object_centric_env.config  # pylint: disable=protected-access
+    unwrapped_env = cast(Packing3DEnv, env.unwrapped)
+    # pylint: disable-next=protected-access
+    config = unwrapped_env._object_centric_env.config
     if MAKE_VIDEOS:
         env = RecordVideo(env, "unit_test_videos")  # type: ignore[assignment]
 


### PR DESCRIPTION
Addressed this issue: https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/issues/89

We are now using shapely.polygon.contain to check the goal condition, instead of `inside`, I added a unit test function where `is_inside` returns false, but the goal is actually achieved.