### PR TITLE
Add point cloud generation for Dynamic3D MuJoCo environments

### DIFF
--- a/scripts/visualize_point_clouds.py
+++ b/scripts/visualize_point_clouds.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Visualise Dynamic3D scene point clouds generated from MuJoCo depth rendering.
+
+Renders RGB + depth images from every named camera in the scene, back-projects
+the valid pixels into world-frame 3-D positions, and displays the merged point
+cloud with matplotlib.  Optionally saves the point cloud to a .npz file.
+
+Usage
+-----
+::
+
+    # visualise the default BalanceBeam3D environment
+    python scripts/visualize_point_clouds.py
+
+    # choose a specific env and seed
+    python scripts/visualize_point_clouds.py \\
+        --env-id kinder/Dynamo3D-o3-v0 --seed 42
+
+    # restrict to a subset of cameras
+    python scripts/visualize_point_clouds.py \\
+        --env-id kinder/BalanceBeam3D-o3-v0 \\
+        --cameras task_view robot_base robot_wrist
+
+    # save the point cloud to disk (numpy .npz) without showing a plot
+    python scripts/visualize_point_clouds.py \\
+        --save-npz /tmp/scene_pc.npz --no-show
+
+    # render at higher resolution
+    python scripts/visualize_point_clouds.py --width 1280 --height 960
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import mujoco  # type: ignore[import-untyped]
+import numpy as np
+from mpl_toolkits.mplot3d import Axes3D  # type: ignore[import-untyped]  # noqa: F401  # pylint: disable=unused-import
+
+# ── project root on path (must precede kinder imports) ──────────────────────
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+import kinder  # pylint: disable=wrong-import-position
+from kinder.envs.dynamic3d.point_cloud import (  # pylint: disable=wrong-import-position
+    PointCloud,
+    generate_scene_point_cloud,
+    get_sim_from_env,
+)
+from kinder.envs.dynamic3d.point_cloud import (  # pylint: disable=wrong-import-position
+    depth_buffer_to_metric,
+)
+
+
+# ---------------------------------------------------------------------------
+# Plotting helpers
+# ---------------------------------------------------------------------------
+
+_CAMERA_PALETTE = [
+    [0.90, 0.30, 0.30],  # red
+    [0.30, 0.70, 0.30],  # green
+    [0.30, 0.50, 0.90],  # blue
+    [0.90, 0.80, 0.20],  # yellow
+    [0.80, 0.40, 0.90],  # purple
+    [0.20, 0.80, 0.80],  # cyan
+    [0.90, 0.60, 0.20],  # orange
+    [0.60, 0.90, 0.40],  # lime
+]
+
+
+def _subsample(
+    xyz: np.ndarray,
+    rgb: np.ndarray,
+    max_pts: int = 50_000,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Randomly sub-sample a point cloud for faster rendering."""
+    n = len(xyz)
+    if n <= max_pts:
+        return xyz, rgb
+    idx = np.random.default_rng(0).choice(n, max_pts, replace=False)
+    return xyz[idx], rgb[idx]
+
+
+def plot_point_cloud_rgb(
+    pc: PointCloud,
+    ax: "plt.Axes",
+    *,
+    max_pts: int = 50_000,
+    point_size: float = 0.5,
+) -> None:
+    """Scatter-plot the point cloud coloured by the RGB texture."""
+    xyz, rgb = _subsample(pc.xyz, pc.rgb, max_pts)
+    colours = rgb.astype(np.float32) / 255.0
+    ax.scatter(  # type: ignore[misc]
+        xyz[:, 0], xyz[:, 1], xyz[:, 2],
+        c=colours,
+        s=point_size,
+        marker=".",
+        linewidths=0,
+    )
+    ax.set_xlabel("X (m)")
+    ax.set_ylabel("Y (m)")
+    ax.set_zlabel("Z (m)")  # type: ignore[attr-defined]
+    ax.set_title("Point cloud — RGB colour")
+
+
+def plot_point_cloud_by_camera(
+    pc: PointCloud,
+    ax: "plt.Axes",
+    *,
+    max_pts: int = 50_000,
+    point_size: float = 0.5,
+) -> None:
+    """Scatter-plot the point cloud with each camera in a distinct colour."""
+    for cam_idx, cname in enumerate(pc.camera_names):
+        mask = pc.camera_indices == cam_idx
+        if not np.any(mask):
+            continue
+        xyz_cam = pc.xyz[mask]
+        n = len(xyz_cam)
+        if n > max_pts // max(len(pc.camera_names), 1):
+            rng = np.random.default_rng(cam_idx)
+            keep = rng.choice(n, max_pts // max(len(pc.camera_names), 1), replace=False)
+            xyz_cam = xyz_cam[keep]
+        colour = _CAMERA_PALETTE[cam_idx % len(_CAMERA_PALETTE)]
+        ax.scatter(  # type: ignore[misc]
+            xyz_cam[:, 0], xyz_cam[:, 1], xyz_cam[:, 2],
+            c=[colour],
+            s=point_size,
+            marker=".",
+            linewidths=0,
+            label=cname,
+        )
+    ax.set_xlabel("X (m)")
+    ax.set_ylabel("Y (m)")
+    ax.set_zlabel("Z (m)")  # type: ignore[attr-defined]
+    ax.set_title("Point cloud — per-camera colour")
+    ax.legend(loc="upper right", markerscale=8, fontsize="small")
+
+
+def _build_name2id(mj_model: Any) -> dict[str, int]:
+    """Build a camera-name → camera-id mapping from a MuJoCo model."""
+    name2id: dict[str, int] = {}
+    for i in range(mj_model.ncam):
+        name = mujoco.mj_id2name(  # pylint: disable=no-member
+            mj_model, mujoco.mjtObj.mjOBJ_CAMERA, i  # pylint: disable=no-member
+        )
+        if name is not None:
+            name2id[name] = i
+    return name2id
+
+
+def plot_rgb_views(
+    env_id: str,
+    sim: Any,
+    camera_names: list[str],
+    width: int,
+    height: int,
+) -> "plt.Figure":
+    """Show side-by-side RGB renders from each camera."""
+    mj_model = sim.model.mj_model
+    ctx = sim._render_context_offscreen  # pylint: disable=protected-access
+    name2id = _build_name2id(mj_model)
+
+    n_cams = len(camera_names)
+    fig, axes = plt.subplots(
+        1, n_cams, figsize=(4 * n_cams, 3.5), squeeze=False
+    )
+    fig.suptitle(f"RGB renders — {env_id}", fontsize=10)
+
+    for col, cname in enumerate(camera_names):
+        cam_id = name2id.get(cname)
+        ax = axes[0][col]
+        if cam_id is None:
+            ax.set_title(f"{cname}\n(not found)")
+            ax.axis("off")
+            continue
+        ctx.render(width=width, height=height, camera_id=cam_id)
+        rgb_depth = ctx.read_pixels(width, height, depth=False)
+        if isinstance(rgb_depth, tuple):
+            rgb_img = rgb_depth[0]
+        else:
+            rgb_img = rgb_depth
+        ax.imshow(rgb_img)
+        ax.set_title(cname, fontsize=9)
+        ax.axis("off")
+
+    fig.tight_layout()
+    return fig
+
+
+def plot_depth_views(
+    env_id: str,
+    sim: Any,
+    camera_names: list[str],
+    width: int,
+    height: int,
+) -> "plt.Figure":
+    """Show side-by-side linearised metric depth renders from each camera."""
+    mj_model = sim.model.mj_model
+    ctx = sim._render_context_offscreen  # pylint: disable=protected-access
+    name2id = _build_name2id(mj_model)
+
+    n_cams = len(camera_names)
+    fig, axes = plt.subplots(
+        1, n_cams, figsize=(4 * n_cams, 3.5), squeeze=False
+    )
+    fig.suptitle(f"Metric depth (m) — {env_id}", fontsize=10)
+
+    for col, cname in enumerate(camera_names):
+        cam_id = name2id.get(cname)
+        ax = axes[0][col]
+        if cam_id is None:
+            ax.set_title(f"{cname}\n(not found)")
+            ax.axis("off")
+            continue
+        ctx.render(width=width, height=height, camera_id=cam_id)
+        rgb_depth = ctx.read_pixels(width, height, depth=True)
+        assert isinstance(rgb_depth, tuple)
+        _, depth_raw = rgb_depth
+        assert depth_raw is not None
+        z_m = depth_buffer_to_metric(depth_raw, mj_model)
+        z_vis = np.where(np.isfinite(z_m), z_m, np.nan)
+        im = ax.imshow(z_vis, cmap="turbo")
+        ax.set_title(cname, fontsize=9)
+        ax.axis("off")
+        fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04, label="m")
+
+    fig.tight_layout()
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Statistics printer
+# ---------------------------------------------------------------------------
+
+
+def print_summary(pc: PointCloud, env_id: str) -> None:
+    """Print a brief point-cloud summary to stdout."""
+    print(f"\n{'='*60}")
+    print(f"Environment : {env_id}")
+    print(f"Total points: {len(pc):,}")
+    if len(pc) > 0:
+        print(f"X  range    : [{pc.xyz[:,0].min():.3f}, {pc.xyz[:,0].max():.3f}] m")
+        print(f"Y  range    : [{pc.xyz[:,1].min():.3f}, {pc.xyz[:,1].max():.3f}] m")
+        print(f"Z  range    : [{pc.xyz[:,2].min():.3f}, {pc.xyz[:,2].max():.3f}] m")
+    print(f"Cameras     : {pc.camera_names}")
+    for cam_idx, cname in enumerate(pc.camera_names):
+        n = int((pc.camera_indices == cam_idx).sum())
+        print(f"  {cname}: {n:,} points")
+    print("=" * 60)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    p = argparse.ArgumentParser(
+        description="Visualise Dynamic3D scene point clouds from MuJoCo depth rendering",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--env-id",
+        default="kinder/BalanceBeam3D-o3-v0",
+        help="kinder environment ID",
+    )
+    p.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="RNG seed for env.reset()",
+    )
+    p.add_argument(
+        "--cameras",
+        nargs="*",
+        default=None,
+        metavar="CAM",
+        help=(
+            "Camera names to render (default: all named cameras in the model). "
+            "Example: --cameras task_view robot_base"
+        ),
+    )
+    p.add_argument(
+        "--width",
+        type=int,
+        default=640,
+        help="Render width in pixels",
+    )
+    p.add_argument(
+        "--height",
+        type=int,
+        default=480,
+        help="Render height in pixels",
+    )
+    p.add_argument(
+        "--max-depth",
+        type=float,
+        default=10.0,
+        help="Discard points further than this distance (metres)",
+    )
+    p.add_argument(
+        "--min-depth",
+        type=float,
+        default=0.01,
+        help="Discard points closer than this distance (metres)",
+    )
+    p.add_argument(
+        "--max-pts",
+        type=int,
+        default=80_000,
+        help="Maximum points shown per 3-D plot (sub-sampled for speed)",
+    )
+    p.add_argument(
+        "--save-npz",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Save the point cloud as a .npz file (xyz, rgb, camera_indices)",
+    )
+    p.add_argument(
+        "--save-figs",
+        type=str,
+        default=None,
+        metavar="PREFIX",
+        help=(
+            "Save figures as PNG files with this prefix "
+            "(e.g. /tmp/pc → /tmp/pc_rgb.png, /tmp/pc_by_cam.png, …)"
+        ),
+    )
+    p.add_argument(
+        "--no-show",
+        action="store_true",
+        help="Do not call plt.show() (useful in headless / scripted runs)",
+    )
+    p.add_argument(
+        "--no-3d",
+        action="store_true",
+        help="Skip the 3-D scatter plots (only show RGB / depth views)",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    """Generate and visualise a scene point cloud for a Dynamic3D environment."""
+    args = parse_args()
+
+    # ── register environments ────────────────────────────────────────────────
+    kinder.register_all_environments()
+
+    # ── create and reset env ────────────────────────────────────────────────
+    print(f"Loading environment: {args.env_id}")
+    env = kinder.make(args.env_id)
+    env.reset(seed=args.seed)
+    print(f"Environment reset (seed={args.seed})")
+
+    # ── get sim ─────────────────────────────────────────────────────────────
+    sim = get_sim_from_env(env)
+
+    # ── discover available cameras ──────────────────────────────────────────
+    mj_model = sim.model.mj_model
+    all_cam_names = list(_build_name2id(mj_model).keys())
+
+    print(f"Available cameras in model: {all_cam_names}")
+
+    camera_names: list[str] | None = args.cameras
+    if camera_names is not None:
+        # Validate
+        unknown = [c for c in camera_names if c not in all_cam_names]
+        if unknown:
+            print(
+                f"\nWarning: cameras not found in model and will be skipped: {unknown}"
+            )
+        camera_names = [c for c in camera_names if c in all_cam_names]
+        if not camera_names:
+            print("No valid cameras to render.  Exiting.")
+            env.close()
+            return
+    else:
+        camera_names = all_cam_names
+
+    # ── generate point cloud ─────────────────────────────────────────────────
+    print(
+        f"\nGenerating point cloud from {len(camera_names)} camera(s): {camera_names}"
+    )
+    pc = generate_scene_point_cloud(
+        sim,
+        camera_names=camera_names,
+        width=args.width,
+        height=args.height,
+        max_depth=args.max_depth,
+        min_depth=args.min_depth,
+    )
+    print_summary(pc, args.env_id)
+
+    # ── optionally save ──────────────────────────────────────────────────────
+    if args.save_npz and len(pc) > 0:
+        save_path = Path(args.save_npz)
+        np.savez_compressed(save_path, **pc.to_dict())
+        print(f"\nPoint cloud saved to: {save_path}")
+
+    # ── RGB and depth views ──────────────────────────────────────────────────
+    fig_rgb = plot_rgb_views(args.env_id, sim, camera_names, args.width, args.height)
+    if args.save_figs:
+        fig_rgb.savefig(f"{args.save_figs}_rgb_views.png", dpi=150, bbox_inches="tight")
+        print(f"Saved: {args.save_figs}_rgb_views.png")
+
+    fig_depth = plot_depth_views(
+        args.env_id, sim, camera_names, args.width, args.height
+    )
+    if args.save_figs:
+        fig_depth.savefig(
+            f"{args.save_figs}_depth_views.png", dpi=150, bbox_inches="tight"
+        )
+        print(f"Saved: {args.save_figs}_depth_views.png")
+
+    # ── 3-D point cloud plots ─────────────────────────────────────────────────
+    if not args.no_3d and len(pc) > 0:
+        # Figure 1: RGB colour
+        fig_3d_rgb = plt.figure(figsize=(9, 7))
+        ax_rgb = fig_3d_rgb.add_subplot(111, projection="3d")
+        plot_point_cloud_rgb(pc, ax_rgb, max_pts=args.max_pts)
+        fig_3d_rgb.tight_layout()
+        if args.save_figs:
+            fig_3d_rgb.savefig(
+                f"{args.save_figs}_3d_rgb.png", dpi=150, bbox_inches="tight"
+            )
+            print(f"Saved: {args.save_figs}_3d_rgb.png")
+
+        # Figure 2: per-camera colour
+        fig_3d_cam = plt.figure(figsize=(9, 7))
+        ax_cam = fig_3d_cam.add_subplot(111, projection="3d")
+        plot_point_cloud_by_camera(pc, ax_cam, max_pts=args.max_pts)
+        fig_3d_cam.tight_layout()
+        if args.save_figs:
+            fig_3d_cam.savefig(
+                f"{args.save_figs}_3d_by_camera.png", dpi=150, bbox_inches="tight"
+            )
+            print(f"Saved: {args.save_figs}_3d_by_camera.png")
+
+        # Figure 3: combined panel — 2D projections (XY, XZ, YZ) + 3D
+        fig_panel, axes_panel = plt.subplots(1, 4, figsize=(18, 4))
+        fig_panel.suptitle(
+            f"Point cloud projections — {args.env_id} (seed={args.seed})", fontsize=10
+        )
+
+        sub_xyz, sub_rgb = _subsample(pc.xyz, pc.rgb, args.max_pts)
+        colours = sub_rgb.astype(np.float32) / 255.0
+
+        proj_labels = [("X", "Y", 0, 1), ("X", "Z", 0, 2), ("Y", "Z", 1, 2)]
+        for ax, (xl, yl, xi, yi) in zip(axes_panel[:3], proj_labels):
+            ax.scatter(sub_xyz[:, xi], sub_xyz[:, yi], c=colours, s=0.3, linewidths=0)
+            ax.set_xlabel(f"{xl} (m)")
+            ax.set_ylabel(f"{yl} (m)")
+            ax.set_title(f"{xl}–{yl} projection")
+            ax.set_aspect("equal", "datalim")
+
+        # 3-D in last panel slot (recreate as 3-D axes)
+        axes_panel[3].remove()
+        ax_3d = fig_panel.add_subplot(1, 4, 4, projection="3d")
+        ax_3d.scatter(
+            sub_xyz[:, 0], sub_xyz[:, 1], sub_xyz[:, 2],
+            c=colours, s=0.3, linewidths=0
+        )
+        ax_3d.set_xlabel("X")
+        ax_3d.set_ylabel("Y")
+        ax_3d.set_zlabel("Z")  # type: ignore[attr-defined]
+        ax_3d.set_title("3-D view")
+
+        fig_panel.tight_layout()
+        if args.save_figs:
+            fig_panel.savefig(
+                f"{args.save_figs}_panel.png", dpi=150, bbox_inches="tight"
+            )
+            print(f"Saved: {args.save_figs}_panel.png")
+
+    elif not args.no_3d and len(pc) == 0:
+        print("\nWarning: point cloud is empty — nothing to plot in 3-D.")
+
+    # ── show ─────────────────────────────────────────────────────────────────
+    if not args.no_show:
+        plt.show()
+
+    env.close()
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kinder/envs/dynamic3d/point_cloud.py
+++ b/src/kinder/envs/dynamic3d/point_cloud.py
@@ -1,0 +1,411 @@
+"""Point cloud generation for Dynamic3D MuJoCo environments.
+
+Generates dense, colored 3D point clouds from depth + RGB rendering across
+one or more named cameras. The per-pixel back-projection uses each camera's
+intrinsics (from cam_fovy) and extrinsics (cam_xpos / cam_xmat) live from
+the simulation data so point clouds track the current physics state.
+
+Typical usage
+-------------
+::
+
+    env = kinder.make("kinder/BalanceBeam3D-o3-v0")
+    env.reset(seed=0)
+
+    sim = get_sim_from_env(env)
+    pc = generate_scene_point_cloud(sim)   # uses all env cameras
+
+    # pc.xyz  -> (N, 3) float32 world-frame positions
+    # pc.rgb  -> (N, 3) uint8  colours  [0, 255]
+
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+
+import mujoco  # type: ignore
+import numpy as np
+from numpy.typing import NDArray
+
+
+# ---------------------------------------------------------------------------
+# Public data type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PointCloud:
+    """Merged, world-frame coloured point cloud from one or more cameras.
+
+    Attributes:
+        xyz: (N, 3) float32 array of world-frame XYZ positions.
+        rgb: (N, 3) uint8 array of RGB colours in [0, 255].
+        camera_indices: (N,) int array mapping each point to its source
+            camera index in ``camera_names``.
+        camera_names: Ordered list of camera names that contributed points.
+    """
+
+    xyz: NDArray[np.float32]
+    rgb: NDArray[np.uint8]
+    camera_indices: NDArray[np.int32]
+    camera_names: list[str] = field(default_factory=list)
+
+    def __len__(self) -> int:
+        return int(self.xyz.shape[0])
+
+    def filter_by_camera(self, name: str) -> "PointCloud":
+        """Return a new PointCloud with only the points from *name*."""
+        if name not in self.camera_names:
+            raise ValueError(
+                f"Camera '{name}' not in point cloud. "
+                f"Available cameras: {self.camera_names}"
+            )
+        idx = self.camera_names.index(name)
+        mask = self.camera_indices == idx
+        return PointCloud(
+            xyz=self.xyz[mask],
+            rgb=self.rgb[mask],
+            camera_indices=self.camera_indices[mask],
+            camera_names=[name],
+        )
+
+    def to_dict(self) -> dict[str, NDArray]:
+        """Serialise to a plain dict (e.g. for np.savez)."""
+        return {
+            "xyz": self.xyz,
+            "rgb": self.rgb,
+            "camera_indices": self.camera_indices,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Intrinsics / extrinsics helpers
+# ---------------------------------------------------------------------------
+
+
+def get_camera_intrinsics(
+    model: mujoco.MjModel,  # type: ignore[name-defined]
+    cam_id: int,
+    width: int,
+    height: int,
+) -> NDArray[np.float64]:
+    """Return the 3×3 intrinsic matrix K for a MuJoCo fixed camera.
+
+    MuJoCo uses a single vertical field-of-view (``cam_fovy``, in degrees)
+    and assumes square pixels, so ``fx == fy``.
+
+    Args:
+        model: The MuJoCo model.
+        cam_id: Zero-based camera index.
+        width: Render width in pixels.
+        height: Render height in pixels.
+
+    Returns:
+        K: 3×3 float64 intrinsics matrix::
+
+            [[fx,  0, cx],
+             [ 0, fy, cy],
+             [ 0,  0,  1]]
+    """
+    fovy_deg: float = float(model.cam_fovy[cam_id])
+    fovy_rad = math.radians(fovy_deg)
+    fy = height / (2.0 * math.tan(fovy_rad / 2.0))
+    fx = fy  # MuJoCo cameras have square pixels
+    cx = width / 2.0
+    cy = height / 2.0
+    return np.array([[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]], dtype=np.float64)
+
+
+def get_camera_extrinsics(
+    data: mujoco.MjData,  # type: ignore[name-defined]
+    cam_id: int,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Return the camera-to-world rotation and translation.
+
+    MuJoCo's ``cam_xmat`` stores the camera frame orientation as a 9-element
+    row-major rotation matrix whose *columns* are the camera X, Y, Z axes
+    expressed in world coordinates (camera-to-world, same convention as
+    ``xmat`` for bodies).  The camera Z axis points *backward* (away from
+    the scene).
+
+    Args:
+        data: MuJoCo simulation data (after ``mj_forward``).
+        cam_id: Zero-based camera index.
+
+    Returns:
+        R_c2w: (3, 3) rotation matrix, camera → world.
+        t_w: (3,) camera position in world frame.
+    """
+    R_c2w = data.cam_xmat[cam_id].reshape(3, 3).copy().astype(np.float64)
+    t_w = data.cam_xpos[cam_id].copy().astype(np.float64)
+    return R_c2w, t_w
+
+
+def depth_buffer_to_metric(
+    depth_raw: NDArray[np.float32],
+    model: mujoco.MjModel,  # type: ignore[name-defined]
+) -> NDArray[np.float64]:
+    """Convert a raw MuJoCo depth buffer to metric distances (metres).
+
+    MuJoCo uses the standard OpenGL non-linear depth buffer where the stored
+    value ``d ∈ [0, 1]`` relates to metric depth ``z`` via::
+
+        z = znear * zfar / (zfar − d * (zfar − znear))
+
+    where ``znear = vis.map.znear * stat.extent`` and similarly for
+    ``zfar``.
+
+    Args:
+        depth_raw: (H, W) float32 array of raw depth buffer values in [0, 1].
+        model: The MuJoCo model (needed for clipping-plane parameters).
+
+    Returns:
+        z_metric: (H, W) float64 array of metric distances along the optical
+            axis.  Pixels at or beyond the far plane are mapped to ``inf``.
+    """
+    extent: float = float(model.stat.extent)
+    znear: float = float(model.vis.map.znear) * extent
+    zfar: float = float(model.vis.map.zfar) * extent
+    d = depth_raw.astype(np.float64)
+    denom = zfar - d * (zfar - znear)
+    # Guard against divide-by-zero (shouldn't happen within [0,1] range)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        z = np.where(denom > 0.0, znear * zfar / denom, np.inf)
+    return z
+
+
+# ---------------------------------------------------------------------------
+# Per-camera back-projection
+# ---------------------------------------------------------------------------
+
+
+def rgbd_to_point_cloud(
+    rgb: NDArray[np.uint8],
+    depth_raw: NDArray[np.float32],
+    cam_id: int,
+    model: mujoco.MjModel,  # type: ignore[name-defined]
+    data: mujoco.MjData,  # type: ignore[name-defined]
+    *,
+    max_depth: float = 10.0,
+    min_depth: float = 0.01,
+) -> tuple[NDArray[np.float32], NDArray[np.uint8]]:
+    """Back-project an RGBD image pair into a world-frame point cloud.
+
+    Pixels whose metric depth falls outside [``min_depth``, ``max_depth``]
+    are discarded.
+
+    Args:
+        rgb: (H, W, 3) uint8 RGB image.
+        depth_raw: (H, W) float32 raw MuJoCo depth buffer (values in [0, 1]).
+            The image must already be flipped vertically (as returned by
+            ``MjSim.render``).
+        cam_id: Zero-based camera index in the model.
+        model: MuJoCo model (for intrinsics and depth conversion).
+        data: MuJoCo data (for extrinsics).
+        max_depth: Discard points farther than this distance (metres).
+        min_depth: Discard points closer than this distance (metres).
+
+    Returns:
+        xyz_world: (N, 3) float32 positions in world frame.
+        rgb_points: (N, 3) uint8 colours.
+    """
+    height, width = depth_raw.shape
+    K = get_camera_intrinsics(model, cam_id, width, height)
+    R_c2w, t_w = get_camera_extrinsics(data, cam_id)
+
+    z_metric = depth_buffer_to_metric(depth_raw, model)  # (H, W)
+
+    # Build pixel grid
+    u = np.arange(width, dtype=np.float64)   # (W,)
+    v = np.arange(height, dtype=np.float64)  # (H,)
+    uu, vv = np.meshgrid(u, v)               # (H, W) each
+
+    # Valid mask
+    mask = (z_metric >= min_depth) & (z_metric <= max_depth) & np.isfinite(z_metric)
+    if not np.any(mask):
+        empty = np.empty((0, 3), dtype=np.float32)
+        return empty, np.empty((0, 3), dtype=np.uint8)
+
+    z = z_metric[mask]        # (N,)
+    u_m = uu[mask]            # (N,)
+    v_m = vv[mask]            # (N,)
+
+    # Back-project to camera frame.
+    # MuJoCo camera convention: X = right, Y = up, Z = backward.
+    # The optical axis points in the -Z direction.
+    fx, fy, cx, cy = K[0, 0], K[1, 1], K[0, 2], K[1, 2]
+    x_cam = (u_m - cx) / fx * z
+    y_cam = -(v_m - cy) / fy * z  # flip: image v increases down, camera Y up
+    z_cam = -z                     # camera looks in -Z
+
+    pts_cam = np.stack([x_cam, y_cam, z_cam], axis=-1)  # (N, 3)
+
+    # Transform to world frame: p_w = R_c2w @ p_c + t_w
+    xyz_world = (pts_cam @ R_c2w.T + t_w).astype(np.float32)
+
+    rgb_points = rgb[mask].astype(np.uint8)
+    return xyz_world, rgb_points
+
+
+# ---------------------------------------------------------------------------
+# MjSim-level API
+# ---------------------------------------------------------------------------
+
+
+def generate_scene_point_cloud(
+    sim: "MjSim",  # type: ignore[name-defined]  # kinder MjSim
+    camera_names: Sequence[str] | None = None,
+    *,
+    width: int = 640,
+    height: int = 480,
+    max_depth: float = 10.0,
+    min_depth: float = 0.01,
+) -> PointCloud:
+    """Generate a merged world-frame point cloud from one or more cameras.
+
+    Renders each requested camera's RGB + depth image, back-projects the
+    valid pixels into world-frame 3-D positions, and concatenates the
+    results into a single :class:`PointCloud`.
+
+    Args:
+        sim: A ``kinder`` :class:`MjSim` instance (already reset and
+            forwarded).
+        camera_names: Camera names to use.  Pass ``None`` to use every
+            named camera in the model.
+        width: Render width in pixels.
+        height: Render height in pixels.
+        max_depth: Maximum metric depth to keep (metres).
+        min_depth: Minimum metric depth to keep (metres).
+
+    Returns:
+        A :class:`PointCloud` containing the merged scene geometry.
+
+    Raises:
+        ValueError: If a requested camera name is not found in the model.
+    """
+    mj_model: mujoco.MjModel = sim.model.mj_model  # type: ignore[name-defined]
+    mj_data: mujoco.MjData = sim.data.mj_data  # type: ignore[name-defined]
+
+    # Resolve camera names → camera IDs
+    name2id: dict[str, int] = {}
+    for i in range(mj_model.ncam):
+        name = mujoco.mj_id2name(  # pylint: disable=no-member
+            mj_model, mujoco.mjtObj.mjOBJ_CAMERA, i  # pylint: disable=no-member
+        )
+        if name is not None:
+            name2id[name] = i
+
+    if camera_names is None:
+        # Use all named cameras
+        cam_items = list(name2id.items())
+    else:
+        cam_items = []
+        for cname in camera_names:
+            if cname not in name2id:
+                raise ValueError(
+                    f"Camera '{cname}' not found in model. "
+                    f"Available cameras: {list(name2id.keys())}"
+                )
+            cam_items.append((cname, name2id[cname]))
+
+    if not cam_items:
+        empty_f = np.empty((0, 3), dtype=np.float32)
+        empty_u = np.empty((0, 3), dtype=np.uint8)
+        empty_i = np.empty((0,), dtype=np.int32)
+        return PointCloud(xyz=empty_f, rgb=empty_u, camera_indices=empty_i)
+
+    all_xyz: list[NDArray[np.float32]] = []
+    all_rgb: list[NDArray[np.uint8]] = []
+    all_idx: list[NDArray[np.int32]] = []
+    resolved_names: list[str] = []
+
+    ctx = sim._render_context_offscreen  # pylint: disable=protected-access
+
+    for local_idx, (cname, cam_id) in enumerate(cam_items):
+        ctx.render(width=width, height=height, camera_id=cam_id)
+        rgb_depth = ctx.read_pixels(width, height, depth=True)
+        assert isinstance(rgb_depth, tuple)
+        rgb_img, depth_img = rgb_depth
+        assert depth_img is not None
+
+        xyz, rgb = rgbd_to_point_cloud(
+            rgb_img,
+            depth_img,
+            cam_id,
+            mj_model,
+            mj_data,
+            max_depth=max_depth,
+            min_depth=min_depth,
+        )
+
+        if len(xyz) > 0:
+            all_xyz.append(xyz)
+            all_rgb.append(rgb)
+            all_idx.append(
+                np.full(len(xyz), local_idx, dtype=np.int32)
+            )
+        resolved_names.append(cname)
+
+    if not all_xyz:
+        empty_f = np.empty((0, 3), dtype=np.float32)
+        empty_u = np.empty((0, 3), dtype=np.uint8)
+        empty_i = np.empty((0,), dtype=np.int32)
+        return PointCloud(xyz=empty_f, rgb=empty_u, camera_indices=empty_i,
+                          camera_names=resolved_names)
+
+    return PointCloud(
+        xyz=np.concatenate(all_xyz, axis=0),
+        rgb=np.concatenate(all_rgb, axis=0),
+        camera_indices=np.concatenate(all_idx, axis=0),
+        camera_names=resolved_names,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Convenience: extract sim from a wrapped kinder env
+# ---------------------------------------------------------------------------
+
+
+def get_sim_from_env(env: Any) -> "MjSim":  # type: ignore[name-defined]
+    """Extract the underlying :class:`MjSim` from a wrapped kinder env.
+
+    Works with the standard ``kinder.make(...)`` wrapper stack::
+
+        kinder_wrapper
+          └─ ObjectCentricRobotEnv (_object_centric_env)
+               └─ RobotEnv         (_robot_env)
+                    └─ MujocoEnv   (sim)
+
+    Args:
+        env: Any gymnasium-wrapped kinder environment.
+
+    Returns:
+        The ``MjSim`` instance (guaranteed non-None after a reset).
+
+    Raises:
+        RuntimeError: If the expected attributes are not found, or if the
+            sim has not been initialised (i.e. no reset has been called yet).
+    """
+    unwrapped = env.unwrapped
+
+    # Path: object_centric_env → _robot_env → sim
+    if hasattr(unwrapped, "_object_centric_env"):
+        robot_env = unwrapped._object_centric_env._robot_env  # pylint: disable=protected-access
+    elif hasattr(unwrapped, "_robot_env"):
+        robot_env = unwrapped._robot_env  # pylint: disable=protected-access
+    else:
+        raise RuntimeError(
+            "Cannot locate a robot env inside the provided environment. "
+            "Expected either '_object_centric_env._robot_env' or '_robot_env' "
+            f"on {type(unwrapped).__name__}."
+        )
+
+    sim = robot_env.sim
+    if sim is None:
+        raise RuntimeError(
+            "sim is None — call env.reset() before generating a point cloud."
+        )
+    return sim


### PR DESCRIPTION
## Summary

Adds point cloud generation for Dynamic3D MuJoCo environments, enabling dense RGB+XYZ scene representations from any set of named cameras via depth rendering.

## New files

### `src/kinder/envs/dynamic3d/point_cloud.py`

Core module with the following public API:

| Symbol | Description |
|--------|-------------|
| `PointCloud` | Dataclass holding `xyz (N,3) float32`, `rgb (N,3) uint8`, `camera_indices (N,)` and `camera_names`. Supports `filter_by_camera()` and `to_dict()` for serialisation. |
| `get_camera_intrinsics(model, cam_id, w, h)` | Builds the 3×3 intrinsic matrix K from `cam_fovy` (square-pixel MuJoCo cameras). |
| `get_camera_extrinsics(data, cam_id)` | Returns the camera-to-world rotation `R` and translation `t` from `cam_xmat` / `cam_xpos`. |
| `depth_buffer_to_metric(depth_raw, model)` | Converts raw MuJoCo OpenGL depth buffer values to metric distances: `z = znear·zfar / (zfar − d·(zfar − znear))`. |
| `rgbd_to_point_cloud(rgb, depth, cam_id, model, data)` | Back-projects one RGBD image pair into world-frame xyz+rgb, discarding pixels outside `[min_depth, max_depth]`. |
| `generate_scene_point_cloud(sim, camera_names, ...)` | Renders all (or selected) cameras through `MjRenderContextOffscreen` and merges their back-projections into a single `PointCloud`. |
| `get_sim_from_env(env)` | Extracts the `MjSim` from any wrapped kinder gymnasium env. |

### `scripts/visualize_point_clouds.py`

Demo/test script with multiple view modes and CLI flags:

```
--env-id        kinder env to load (default: kinder/BalanceBeam3D-o3-v0)
--seed          reset seed
--cameras       restrict to a subset of cameras
--width/height  render resolution
--max-depth     far-clip in metres
--save-npz      save xyz/rgb/camera_indices as compressed .npz
--save-figs     save all figures as PNGs with this prefix
--no-show       headless / scripted runs
--no-3d         skip 3-D scatter plots
```

Produces five figures: RGB views per camera, metric depth maps, 3-D scatter (RGB-coloured), 3-D scatter (per-camera coloured), and an XY/XZ/YZ projection panel.

## Testing

```bash
# integration test
python scripts/visualize_point_clouds.py \
    --env-id kinder/BalanceBeam3D-o3-v0 --seed 42 \
    --save-figs /tmp/pc --no-show

# single camera
python scripts/visualize_point_clouds.py \
    --env-id kinder/BalanceBeam3D-o3-v0 \
    --cameras task_view

# interactive (requires a display backend)
MPLBACKEND=TkAgg python scripts/visualize_point_clouds.py \
    --env-id kinder/Dynamo3D-o3-v0 --seed 7
```

Both files pass `mypy` (strict) and `pylint` at **10.00/10**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
