### PR TITLE
Enable single-backend installs via requirements files; drop no-op extras

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include src *.py *.typed
 recursive-include src/kinder/envs *.xml *.obj *.mtl *.stl *.urdf *.png *.jpg *.jpeg *.json
 include pyproject.toml README.md LICENSE
+recursive-include requirements *.txt
 prune demos
 prune docs
 prune tests

--- a/README.md
+++ b/README.md
@@ -20,14 +20,24 @@ See [https://prpl-group.com/kinder-site/](https://prpl-group.com/kinder-site/) f
 ### From PyPI
 
 ```bash
-pip install kindergarden                # all environment dependencies
-pip install kindergarden[dynamic2d]     # only dynamic2d environments
-pip install kindergarden[kinematic2d]   # only kinematic2d environments
-pip install kindergarden[kinematic3d]   # only kinematic3d environments
-pip install kindergarden[dynamic3d]     # only dynamic3d environments
+pip install kindergarden   # all environments (PyBullet, MuJoCo, pygame, ...)
 ```
 
-You can also combine extras: `pip install kindergarden[kinematic2d,kinematic3d]`
+#### Installing a single backend (no PyBullet/MuJoCo)
+
+The default install pulls every backend. To install just one — for example the
+kinematic2d environments, which need neither PyBullet nor MuJoCo — install the
+package without its dependencies, then the backend's requirements file:
+
+```bash
+pip install --no-deps kindergarden
+pip install -r https://raw.githubusercontent.com/Princeton-Robot-Planning-and-Learning/kindergarden/main/requirements/kinematic2d.txt
+```
+
+Requirements files are provided for each backend: `kinematic2d`, `dynamic2d`,
+`kinematic3d`, `dynamic3d` (under [`requirements/`](requirements/)). The two-step
+form is needed because pip extras can only *add* dependencies, never remove the
+backends already pulled in by the base install.
 
 ### From Source
 
@@ -39,9 +49,10 @@ cd kindergarden
 uv pip install -e ".[develop]"   # all dependencies + dev tools
 ```
 
-Or install only what you need:
+Or install only one backend (no PyBullet/MuJoCo):
 ```bash
-uv pip install -e ".[dynamic2d]" # only dynamic2d environments
+uv pip install --no-deps -e .
+uv pip install -r requirements/kinematic2d.txt
 ```
 
 To check the installation, run `./run_ci_checks.sh`. It should complete with all green successes.

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -23,10 +23,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "%pip install kindergarden[kinematic2d,dynamic2d]\n",
-    "# Other available extras: kinematic3d, dynamic3d"
-   ]
+   "source": "%pip install kindergarden\n# Installs all backends. To install just one (e.g. the 2D environments, with no\n# PyBullet/MuJoCo), use a requirements file instead -- see the repo's\n# requirements/ directory and the README \"single backend\" install section."
   },
   {
    "cell_type": "code",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Per-backend dependency sets are NOT extras: the base install already pulls
-# every backend, so a `[kinematic2d]`-style extra could only add to that, never
-# slim it. To install a single backend, use the matching file in requirements/
-# (see the README). `pointcloud` is a real extra because it adds packages the
-# base install does not include.
 pointcloud = [
    "h5py>=3",
    "open3d>=0.19.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,10 @@ develop = [
    "mypy",
    "pylint>=2.14.5",
    "pytest-pylint>=0.18.0",
-   "pytest>=7.2.2",
+   # pytest 9.1 dropped the `path` arg from the pytest_collect_file hookspec,
+   # which pytest-pylint 0.21.0 still uses -- it crashes the lint job. Temporary
+   # cap; see issue #111 for the proper fix.
+   "pytest>=7.2.2,<9.1",
    "coverage",
    "gdown>=6.0.0",
    "scipy-stubs>=1.15.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,23 +35,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dynamic2d = [
-   "pygame>=2.5.2",
-   "pymunk==7.1.0",
-   "tomsgeoms2d>=0.0.1",
-]
-kinematic2d = [
-   "tomsgeoms2d>=0.0.1",
-]
-dynamic3d = [
-   "mujoco~=3.3.0",
-   "opencv-python>=4.9.0",
-   "gdown>=6.0.0",
-]
-kinematic3d = [
-   "pybullet-arm64>=3.2.8",
-   "pybullet_helpers>=0.1.0",
-]
+# Per-backend dependency sets are NOT extras: the base install already pulls
+# every backend, so a `[kinematic2d]`-style extra could only add to that, never
+# slim it. To install a single backend, use the matching file in requirements/
+# (see the README). `pointcloud` is a real extra because it adds packages the
+# base install does not include.
 pointcloud = [
    "h5py>=3",
    "open3d>=0.19.0",

--- a/requirements/dynamic2d.txt
+++ b/requirements/dynamic2d.txt
@@ -1,0 +1,15 @@
+# Minimal dependency set for the dynamic2d environments only (no PyBullet or
+# MuJoCo). Mirrors the non-backend base dependencies plus the `dynamic2d` extra
+# in pyproject.toml. See requirements/kinematic2d.txt for usage.
+gymnasium
+matplotlib
+numpy
+Pillow
+dill
+shapely>=2.1.2
+scipy>=1.14.0
+relational_structs>=0.0.1
+prpl_utils>=0.0.1
+pygame>=2.5.2
+pymunk==7.1.0
+tomsgeoms2d>=0.0.1

--- a/requirements/dynamic2d.txt
+++ b/requirements/dynamic2d.txt
@@ -1,6 +1,13 @@
 # Minimal dependency set for the dynamic2d environments only (no PyBullet or
 # MuJoCo). Mirrors the non-backend base dependencies plus the `dynamic2d` extra
-# in pyproject.toml. See requirements/kinematic2d.txt for usage.
+# in pyproject.toml.
+#
+# kindergarden's base install pulls every backend. To install a subset instead,
+# install the package without its dependencies and then this file:
+#
+#     pip install --no-deps kindergarden
+#     pip install -r requirements/dynamic2d.txt
+#
 gymnasium
 matplotlib
 numpy

--- a/requirements/dynamic3d.txt
+++ b/requirements/dynamic3d.txt
@@ -1,0 +1,15 @@
+# Minimal dependency set for the dynamic3d environments only (MuJoCo, no
+# PyBullet). Mirrors the non-backend base dependencies plus the `dynamic3d`
+# extra in pyproject.toml. See requirements/kinematic2d.txt for usage.
+gymnasium
+matplotlib
+numpy
+Pillow
+dill
+shapely>=2.1.2
+scipy>=1.14.0
+relational_structs>=0.0.1
+prpl_utils>=0.0.1
+mujoco~=3.3.0
+opencv-python>=4.9.0
+gdown>=6.0.0

--- a/requirements/dynamic3d.txt
+++ b/requirements/dynamic3d.txt
@@ -1,6 +1,13 @@
 # Minimal dependency set for the dynamic3d environments only (MuJoCo, no
 # PyBullet). Mirrors the non-backend base dependencies plus the `dynamic3d`
-# extra in pyproject.toml. See requirements/kinematic2d.txt for usage.
+# extra in pyproject.toml.
+#
+# kindergarden's base install pulls every backend. To install a subset instead,
+# install the package without its dependencies and then this file:
+#
+#     pip install --no-deps kindergarden
+#     pip install -r requirements/dynamic3d.txt
+#
 gymnasium
 matplotlib
 numpy

--- a/requirements/kinematic2d.txt
+++ b/requirements/kinematic2d.txt
@@ -1,0 +1,20 @@
+# Minimal dependency set for the kinematic2d environments only (no PyBullet,
+# MuJoCo, pygame, or pymunk). Mirrors the non-backend base dependencies plus the
+# `kinematic2d` extra in pyproject.toml.
+#
+# kindergarden's base install pulls every backend. To install a subset instead,
+# install the package without its dependencies and then this file:
+#
+#     pip install --no-deps kindergarden
+#     pip install -r requirements/kinematic2d.txt
+#
+gymnasium
+matplotlib
+numpy
+Pillow
+dill
+shapely>=2.1.2
+scipy>=1.14.0
+relational_structs>=0.0.1
+prpl_utils>=0.0.1
+tomsgeoms2d>=0.0.1

--- a/requirements/kinematic3d.txt
+++ b/requirements/kinematic3d.txt
@@ -1,6 +1,13 @@
 # Minimal dependency set for the kinematic3d environments only (PyBullet, no
 # MuJoCo). Mirrors the non-backend base dependencies plus the `kinematic3d`
-# extra in pyproject.toml. See requirements/kinematic2d.txt for usage.
+# extra in pyproject.toml.
+#
+# kindergarden's base install pulls every backend. To install a subset instead,
+# install the package without its dependencies and then this file:
+#
+#     pip install --no-deps kindergarden
+#     pip install -r requirements/kinematic3d.txt
+#
 gymnasium
 matplotlib
 numpy

--- a/requirements/kinematic3d.txt
+++ b/requirements/kinematic3d.txt
@@ -1,0 +1,14 @@
+# Minimal dependency set for the kinematic3d environments only (PyBullet, no
+# MuJoCo). Mirrors the non-backend base dependencies plus the `kinematic3d`
+# extra in pyproject.toml. See requirements/kinematic2d.txt for usage.
+gymnasium
+matplotlib
+numpy
+Pillow
+dill
+shapely>=2.1.2
+scipy>=1.14.0
+relational_structs>=0.0.1
+prpl_utils>=0.0.1
+pybullet-arm64>=3.2.8
+pybullet_helpers>=0.1.0

--- a/src/kinder/__init__.py
+++ b/src/kinder/__init__.py
@@ -57,9 +57,9 @@ _CATEGORY_DEPS: dict[str, tuple[str, ...]] = {
 def register_all_environments() -> None:
     """Add all benchmark environments to the gymnasium registry.
 
-    Categories whose optional dependencies are not installed are silently
-    skipped.  Install the corresponding extras to enable them, e.g.
-    ``pip install kindergarden[dynamic2d]``.
+    Categories whose backend dependencies are not installed are silently
+    skipped.  The default ``pip install kindergarden`` includes every backend;
+    to install a single one, see the requirements files described in the README.
     """
     # NOTE: ids must start with "kinder/" to be properly registered.
 


### PR DESCRIPTION
## What

Make it possible to install a single backend (e.g. the 2D environments, with no
PyBullet/MuJoCo) and remove the per-backend extras that never actually did this.

## Why

The base install pulls every backend, and pip extras can only **add** to the
base — never remove it. So `pip install kindergarden[kinematic2d]` installed the
full stack anyway, despite the README claiming it installed "only kinematic2d
environments." Those extras were dead weight that misled users.

We intentionally keep `pip install kindergarden` installing everything, and make
subset installs **possible** (not necessarily easy) via a `--no-deps` + per-backend
requirements file:

```bash
pip install --no-deps kindergarden
pip install -r requirements/kinematic2d.txt
```

## Changes

- Add `requirements/{kinematic2d,dynamic2d,kinematic3d,dynamic3d}.txt`.
- Drop the four redundant backend extras. Keep `pointcloud` and `develop` — they
  add packages not in the base install.
- `README.md`: document the real single-backend install; remove the false
  `[kinematic2d]`-slims claims.
- `register_all_environments` docstring: point at the requirements files.
- `notebooks/getting_started.ipynb`: install plain `kindergarden`.
- `MANIFEST.in`: ship `requirements/` in sdists.

## Validation

In a fresh venv, `pip install --no-deps kindergarden` + `requirements/kinematic2d.txt`
installs no PyBullet/MuJoCo/pygame, registers the 2D envs, and builds/resets
`Obstruction2D-o2-v0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
