### PR TITLE
Policy agnostic env descriptions

### DIFF
--- a/src/kinder/envs/dynamic2d/dyn_obstruction2d.py
+++ b/src/kinder/envs/dynamic2d/dyn_obstruction2d.py
@@ -165,8 +165,7 @@ class ObjectCentricDynObstruction2DEnv(
     PyMunk physics simulation.
 
     Key difference from Kinematic2DEnv is that the robot can interact with dynamic
-    objects with realistic physics (friction, collisions, etc). This means some objects
-    should be *pushed* instead of *grasped*.
+    objects with realistic physics (friction, collisions, etc).
     """
 
     def __init__(

--- a/src/kinder/envs/dynamic2d/dyn_pushpullhook2d.py
+++ b/src/kinder/envs/dynamic2d/dyn_pushpullhook2d.py
@@ -755,11 +755,11 @@ class DynPushPullHook2DEnv(ConstantObjectKinDEREnv):
 
     def _create_env_markdown_description(self) -> str:
         # pylint: disable=line-too-long
-        return """A 2D physics-based tool-use environment where a robot must use a hook to push/pull a target block onto a middle wall (goal surface). The target block is positioned in the upper region of the world, while the middle wall is located at the center. The robot must manipulate the hook to navigate the target block downward through obstacles.
+        return """A 2D physics-based environment where the goal is for the target block to reach a middle wall (the goal surface). The target block is positioned in the upper region of the world, while the middle wall is located at the center.
 
-The target block is initially surrounded by obstacle blocks.
+The target block is initially surrounded by obstruction blocks.
 
-The robot has a movable circular base and an extendable arm with gripper fingers. The hook is a kinematic object that can be grasped and used as a tool to indirectly manipulate the target block. All dynamic objects follow PyMunk physics including gravity, friction, and collisions.
+The robot has a movable circular base and an extendable arm with gripper fingers. The hook is a kinematic object that can be grasped. All dynamic objects follow PyMunk physics including gravity, friction, and collisions.
 
 Each object includes physics properties like mass, moment of inertia (for dynamic objects), and color information for rendering.
 """

--- a/src/kinder/envs/dynamic2d/dyn_scooppour2d.py
+++ b/src/kinder/envs/dynamic2d/dyn_scooppour2d.py
@@ -648,9 +648,9 @@ class DynScoopPour2DEnv(ConstantObjectKinDEREnv):
 
     def _create_env_markdown_description(self) -> str:
         # pylint: disable=line-too-long
-        return """A 2D physics-based tool-use environment where a robot must use an L-shaped hook to scoop small objects from the left side of a middle wall and pour them onto the right side. The middle wall is half the height of the world, allowing objects to be scooped over it.
+        return """A 2D physics-based environment where the goal is to move small objects from the left side of a middle wall to the right side. The middle wall is half the height of the world.
 
-The robot has a movable circular base and an extendable arm with gripper fingers. The hook is a kinematic object that can be grasped and used as a tool to scoop the small objects. Small objects are dynamic and follow PyMunk physics, but they cannot be grasped directly by the robot.
+The robot has a movable circular base and an extendable arm with gripper fingers. An L-shaped hook is present as a kinematic object that can be grasped. Small objects are dynamic and follow PyMunk physics, but they cannot be grasped directly by the robot.
 
 All objects include physics properties like mass, moment of inertia, and color information for rendering.
 """

--- a/src/kinder/envs/dynamic2d/dyn_scooppour2d.py
+++ b/src/kinder/envs/dynamic2d/dyn_scooppour2d.py
@@ -151,8 +151,8 @@ class ObjectCentricDynScoopPour2DEnv(
 ):
     """Object-centric dynamic 2D scoop-pour environment.
 
-    The robot must use an L-shaped hook to scoop small objects from the left side of a
-    middle wall and pour them onto the right side.
+    The goal is to move small objects from the left side of a middle wall to the right
+    side.
     """
 
     def __init__(
@@ -662,7 +662,7 @@ All objects include physics properties like mass, moment of inertia, and color i
     def _create_variant_specific_description(self) -> str:
         total = self._num_small_circles + self._num_small_squares
         if total == 1:
-            return "This variant has 1 small object to scoop."
+            return "This variant has 1 small object."
         return (
             f"This variant has {total} small objects "
             f"({self._num_small_circles} circles, {self._num_small_squares} squares)."

--- a/src/kinder/envs/dynamic3d/tasks/BalanceBeam3D/BalanceBeam3D-o3.json
+++ b/src/kinder/envs/dynamic3d/tasks/BalanceBeam3D/BalanceBeam3D-o3.json
@@ -1,5 +1,5 @@
 {
-    "description": "A 3D task where the robot must balance multiple objects onto a balance beam, which requires understanding of spatial relationships between objects of different sizes, and the rotational forces they induce.",
+    "description": "A 3D task where the robot must balance multiple objects onto a balance beam.",
     "variant_description": "This task has one variant with three objects to balance.",
     "variant_specific_description": "Place three cubes onto a seesaw without tipping it past the balance threshold.",
     "robots": {

--- a/src/kinder/envs/dynamic3d/tasks/Dynamo3D/Dynamo3D-o1.json
+++ b/src/kinder/envs/dynamic3d/tasks/Dynamo3D/Dynamo3D-o1.json
@@ -1,5 +1,5 @@
 {
-    "description": "A 3D navigation-among-movable-objects task where the robot must reach a goal region on the floor while several chair obstacles are placed in the workspace and may need to be moved out of the way.",
+    "description": "A 3D navigation-among-movable-objects task where the robot must reach a goal region on the floor while several chair obstacles are placed in the workspace.",
     "variant_description": "The variants differ in the number of obstacle chairs placed in the workspace.",
     "variant_specific_description": "Navigate to a goal region on the floor while avoiding one chair obstacle.",
     "robots": {

--- a/src/kinder/envs/dynamic3d/tasks/Dynamo3D/Dynamo3D-o12.json
+++ b/src/kinder/envs/dynamic3d/tasks/Dynamo3D/Dynamo3D-o12.json
@@ -1,5 +1,5 @@
 {
-    "description": "A 3D navigation-among-movable-objects task where the robot must reach a goal region on the floor while several chair obstacles are placed in the workspace and may need to be moved out of the way.",
+    "description": "A 3D navigation-among-movable-objects task where the robot must reach a goal region on the floor while several chair obstacles are placed in the workspace.",
     "variant_description": "The variants differ in the number of obstacle chairs placed in the workspace.",
     "variant_specific_description": "Navigate to a goal region while avoiding twelve chair obstacles of varying styles.",
     "robots": {

--- a/src/kinder/envs/dynamic3d/tasks/Dynamo3D/Dynamo3D-o3.json
+++ b/src/kinder/envs/dynamic3d/tasks/Dynamo3D/Dynamo3D-o3.json
@@ -1,5 +1,5 @@
 {
-    "description": "A 3D navigation-among-movable-objects task where the robot must reach a goal region on the floor while several chair obstacles are placed in the workspace and may need to be moved out of the way.",
+    "description": "A 3D navigation-among-movable-objects task where the robot must reach a goal region on the floor while several chair obstacles are placed in the workspace.",
     "variant_description": "The variants differ in the number of obstacle chairs placed in the workspace.",
     "variant_specific_description": "Navigate to a goal region while avoiding three chair obstacles of varying styles.",
     "robots": {

--- a/src/kinder/envs/dynamic3d/tasks/ScoopPour3D/ScoopPour3D-o10.json
+++ b/src/kinder/envs/dynamic3d/tasks/ScoopPour3D/ScoopPour3D-o10.json
@@ -1,6 +1,6 @@
 {
     "description": "A 3D task where the robot must transfer a pile of objects from one bin to another.",
-    "variant_description": "The variants require scooping and pouring different numbers of objects.",
+    "variant_description": "The variants require transferring different numbers of objects between bins.",
     "variant_specific_description": "Transfer 10 cubes from a source bin to a target bin on the kitchen island.",
     "robots": {
         "tidybot": {

--- a/src/kinder/envs/dynamic3d/tasks/ScoopPour3D/ScoopPour3D-o10.json
+++ b/src/kinder/envs/dynamic3d/tasks/ScoopPour3D/ScoopPour3D-o10.json
@@ -1,7 +1,7 @@
 {
-    "description": "A 3D task where the robot must transfer a pile of objects from one bin to another. There is a tool available that may be used for scooping and pouring.",
+    "description": "A 3D task where the robot must transfer a pile of objects from one bin to another.",
     "variant_description": "The variants require scooping and pouring different numbers of objects.",
-    "variant_specific_description": "Use a scoop to transfer 10 cubes from a source bin to a target bin on the kitchen island.",
+    "variant_specific_description": "Transfer 10 cubes from a source bin to a target bin on the kitchen island.",
     "robots": {
         "tidybot": {
             "robot": {}

--- a/src/kinder/envs/dynamic3d/tasks/ScoopPour3D/ScoopPour3D-o100.json
+++ b/src/kinder/envs/dynamic3d/tasks/ScoopPour3D/ScoopPour3D-o100.json
@@ -1,7 +1,7 @@
 {
-    "description": "A 3D task where the robot must transfer a pile of objects from one bin to another. There is a tool available that may be used for scooping and pouring.",
+    "description": "A 3D task where the robot must transfer a pile of objects from one bin to another.",
     "variant_description": "The variants require scooping and pouring different numbers of objects.",
-    "variant_specific_description": "Use a scoop to transfer 100 cubes from a source bin to a target bin on the kitchen island.",
+    "variant_specific_description": "Transfer 100 cubes from a source bin to a target bin on the kitchen island.",
     "robots": {
         "tidybot": {
             "robot": {}

--- a/src/kinder/envs/dynamic3d/tasks/ScoopPour3D/ScoopPour3D-o100.json
+++ b/src/kinder/envs/dynamic3d/tasks/ScoopPour3D/ScoopPour3D-o100.json
@@ -1,6 +1,6 @@
 {
     "description": "A 3D task where the robot must transfer a pile of objects from one bin to another.",
-    "variant_description": "The variants require scooping and pouring different numbers of objects.",
+    "variant_description": "The variants require transferring different numbers of objects between bins.",
     "variant_specific_description": "Transfer 100 cubes from a source bin to a target bin on the kitchen island.",
     "robots": {
         "tidybot": {

--- a/src/kinder/envs/dynamic3d/tasks/SortClutteredBlocks3D/SortClutteredBlocks3D-o12-sort_the_blocks_into_the_cupboard.json
+++ b/src/kinder/envs/dynamic3d/tasks/SortClutteredBlocks3D/SortClutteredBlocks3D-o12-sort_the_blocks_into_the_cupboard.json
@@ -1,5 +1,5 @@
 {
-    "description": "A 3D task where the robot must sort a pile of objects into different receptacles based on their color. The objects may be initially in contact with each other, requiring singulation before grasping.",
+    "description": "A 3D task where the robot must sort a pile of objects into different receptacles based on their color. The objects may be initially in contact with each other.",
     "variant_description": "The variants differ in the number of objects to sort and in the types of receptacles (a cupboard or bins).",
     "variant_specific_description": "Sort 9 cubes and 3 cuboids by color into the matching shelves of a single cupboard.",
     "robots": {

--- a/src/kinder/envs/dynamic3d/tasks/SortClutteredBlocks3D/SortClutteredBlocks3D-o20-sort_the_cluttered_blocks_into_bins.json
+++ b/src/kinder/envs/dynamic3d/tasks/SortClutteredBlocks3D/SortClutteredBlocks3D-o20-sort_the_cluttered_blocks_into_bins.json
@@ -1,5 +1,5 @@
 {
-    "description": "A 3D task where the robot must sort a pile of objects into different receptacles based on their color. The objects may be initially in contact with each other, requiring singulation before grasping.",
+    "description": "A 3D task where the robot must sort a pile of objects into different receptacles based on their color. The objects may be initially in contact with each other.",
     "variant_description": "The variants differ in the number of objects to sort and in the types of receptacles (a cupboard or bins).",
     "variant_specific_description": "Sort 20 cubes by color into 4 colored bins on a table.",
     "robots": {

--- a/src/kinder/envs/dynamic3d/tasks/SortClutteredBlocks3D/SortClutteredBlocks3D-o20-sort_the_cluttered_blocks_into_bowls.json
+++ b/src/kinder/envs/dynamic3d/tasks/SortClutteredBlocks3D/SortClutteredBlocks3D-o20-sort_the_cluttered_blocks_into_bowls.json
@@ -1,5 +1,5 @@
 {
-    "description": "A 3D task where the robot must sort a pile of objects into different receptacles based on their color. The objects may be initially in contact with each other, requiring singulation before grasping.",
+    "description": "A 3D task where the robot must sort a pile of objects into different receptacles based on their color. The objects may be initially in contact with each other.",
     "variant_description": "The variants differ in the number of objects to sort and in the types of receptacles (a cupboard or bins).",
     "variant_specific_description": "Sort 20 cubes by color into 4 colored bowls on a table.",
     "robots": {

--- a/src/kinder/envs/dynamic3d/tasks/SortClutteredBlocks3D/SortClutteredBlocks3D-o4-sort_the_cluttered_blocks_into_bins.json
+++ b/src/kinder/envs/dynamic3d/tasks/SortClutteredBlocks3D/SortClutteredBlocks3D-o4-sort_the_cluttered_blocks_into_bins.json
@@ -1,5 +1,5 @@
 {
-    "description": "A 3D task where the robot must sort a pile of objects into different receptacles based on their color. The objects may be initially in contact with each other, requiring singulation before grasping.",
+    "description": "A 3D task where the robot must sort a pile of objects into different receptacles based on their color. The objects may be initially in contact with each other.",
     "variant_description": "The variants differ in the number of objects to sort and in the types of receptacles (a cupboard or bins).",
     "variant_specific_description": "Sort 4 cubes by color into 4 colored bins on a table.",
     "robots": {

--- a/src/kinder/envs/dynamic3d/tasks/SweepIntoDrawer3D/SweepIntoDrawer3D-o5.json
+++ b/src/kinder/envs/dynamic3d/tasks/SweepIntoDrawer3D/SweepIntoDrawer3D-o5.json
@@ -1,7 +1,7 @@
 {
-    "description": "A 3D task where the robot must open a drawer and sweep a pile of objects into the drawer. A brush tool is available that may be used for sweeping.",
+    "description": "A 3D task where the robot must open a drawer and sweep a pile of objects into the drawer.",
     "variant_description": "This task has one variant requiring a fixed number of objects needed to be sweeped into the drawer.",
-    "variant_specific_description": "Open a kitchen-island drawer and use a brush to sweep five cubes into it.",
+    "variant_specific_description": "Open a kitchen-island drawer and sweep five cubes into it.",
     "robots": {
         "tidybot": {
             "robot": {}

--- a/src/kinder/envs/dynamic3d/tasks/SweepSimple3D/SweepSimple3D-o1-sweep_the_blocks_to_the_left_side_of_the_kitchen_island.json
+++ b/src/kinder/envs/dynamic3d/tasks/SweepSimple3D/SweepSimple3D-o1-sweep_the_blocks_to_the_left_side_of_the_kitchen_island.json
@@ -1,7 +1,7 @@
 {
-    "description": "A 3D task where the robot must sweep objects that are spread out on the floor into different regions around fixtures in the room. A broom tool is available that may be used for sweeping.",
+    "description": "A 3D task where the robot must sweep objects that are spread out on the floor into different regions around fixtures in the room.",
     "variant_description": "These variants have different numbers of objects to sweep, and multiple goal locations.",
-    "variant_specific_description": "Use a brush to sweep one cube to the left side of the kitchen island.",
+    "variant_specific_description": "Sweep one cube to the left side of the kitchen island.",
     "robots": {
         "tidybot": {
             "robot": {}

--- a/src/kinder/envs/dynamic3d/tasks/SweepSimple3D/SweepSimple3D-o10-sweep_the_blocks_to_the_left_side_of_the_kitchen_island.json
+++ b/src/kinder/envs/dynamic3d/tasks/SweepSimple3D/SweepSimple3D-o10-sweep_the_blocks_to_the_left_side_of_the_kitchen_island.json
@@ -1,7 +1,7 @@
 {
-    "description": "A 3D task where the robot must sweep objects that are spread out on the floor into different regions around fixtures in the room. A broom tool is available that may be used for sweeping.",
+    "description": "A 3D task where the robot must sweep objects that are spread out on the floor into different regions around fixtures in the room.",
     "variant_description": "These variants have different numbers of objects to sweep, and multiple goal locations.",
-    "variant_specific_description": "Use a brush to sweep ten cubes to the left side of the kitchen island.",
+    "variant_specific_description": "Sweep ten cubes to the left side of the kitchen island.",
     "robots": {
         "tidybot": {
             "robot": {}

--- a/src/kinder/envs/dynamic3d/tasks/SweepSimple3D/SweepSimple3D-o5-sweep_the_blocks_to_the_left_side_of_the_kitchen_island.json
+++ b/src/kinder/envs/dynamic3d/tasks/SweepSimple3D/SweepSimple3D-o5-sweep_the_blocks_to_the_left_side_of_the_kitchen_island.json
@@ -1,7 +1,7 @@
 {
-    "description": "A 3D task where the robot must sweep objects that are spread out on the floor into different regions around fixtures in the room. A broom tool is available that may be used for sweeping.",
+    "description": "A 3D task where the robot must sweep objects that are spread out on the floor into different regions around fixtures in the room.",
     "variant_description": "These variants have different numbers of objects to sweep, and multiple goal locations.",
-    "variant_specific_description": "Use a brush to sweep five cubes to the left side of the kitchen island.",
+    "variant_specific_description": "Sweep five cubes to the left side of the kitchen island.",
     "robots": {
         "tidybot": {
             "robot": {}

--- a/src/kinder/envs/dynamic3d/tasks/SweepSimple3D/SweepSimple3D-o50-sweep_the_blocks_to_the_left_side_of_the_kitchen_island.json
+++ b/src/kinder/envs/dynamic3d/tasks/SweepSimple3D/SweepSimple3D-o50-sweep_the_blocks_to_the_left_side_of_the_kitchen_island.json
@@ -1,7 +1,7 @@
 {
-    "description": "A 3D task where the robot must sweep objects that are spread out on the floor into different regions around fixtures in the room. A broom tool is available that may be used for sweeping.",
+    "description": "A 3D task where the robot must sweep objects that are spread out on the floor into different regions around fixtures in the room.",
     "variant_description": "These variants have different numbers of objects to sweep, and multiple goal locations.",
-    "variant_specific_description": "Use a brush to sweep fifty cubes to the left side of the kitchen island.",
+    "variant_specific_description": "Sweep fifty cubes to the left side of the kitchen island.",
     "robots": {
         "tidybot": {
             "robot": {}

--- a/src/kinder/envs/dynamic3d/tasks/SweepSimple3D/SweepSimple3D-o50-sweep_the_blocks_to_the_right_side_of_the_kitchen_counter.json
+++ b/src/kinder/envs/dynamic3d/tasks/SweepSimple3D/SweepSimple3D-o50-sweep_the_blocks_to_the_right_side_of_the_kitchen_counter.json
@@ -1,7 +1,7 @@
 {
-    "description": "A 3D task where the robot must sweep objects that are spread out on the floor into different regions around fixtures in the room. A broom tool is available that may be used for sweeping.",
+    "description": "A 3D task where the robot must sweep objects that are spread out on the floor into different regions around fixtures in the room.",
     "variant_description": "These variants have different numbers of objects to sweep, and multiple goal locations.",
-    "variant_specific_description": "Use a brush to sweep fifty cubes to the right side of the kitchen counter.",
+    "variant_specific_description": "Sweep fifty cubes to the right side of the kitchen counter.",
     "robots": {
         "tidybot": {
             "robot": {}

--- a/src/kinder/envs/dynamic3d/tasks/SweepSimple3D/SweepSimple3D-o50-sweep_the_blocks_to_the_right_side_of_the_kitchen_island.json
+++ b/src/kinder/envs/dynamic3d/tasks/SweepSimple3D/SweepSimple3D-o50-sweep_the_blocks_to_the_right_side_of_the_kitchen_island.json
@@ -1,7 +1,7 @@
 {
-    "description": "A 3D task where the robot must sweep objects that are spread out on the floor into different regions around fixtures in the room. A broom tool is available that may be used for sweeping.",
+    "description": "A 3D task where the robot must sweep objects that are spread out on the floor into different regions around fixtures in the room.",
     "variant_description": "These variants have different numbers of objects to sweep, and multiple goal locations.",
-    "variant_specific_description": "Use a brush to sweep fifty cubes to the right side of the kitchen island.",
+    "variant_specific_description": "Sweep fifty cubes to the right side of the kitchen island.",
     "robots": {
         "tidybot": {
             "robot": {}

--- a/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
+++ b/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
@@ -1,6 +1,6 @@
 {
     "description": "A 3D task where an object that is initially on the floor must be transferred to the bin.",
-    "variant_description": "The variants require tossing different numbers of objects into the bin.",
+    "variant_description": "The variants require transferring different numbers of objects to the bin.",
     "variant_specific_description": "Get one cube into the bin.",
     "robots": {
         "tidybot": {

--- a/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
+++ b/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
@@ -1,7 +1,7 @@
 {
-    "description": "A 3D task where an object that is initially on the floor must be transferred to the bin. The robot must toss the object into a bin, since it cannot reach the goal position due to an immovable obstacle.",
+    "description": "A 3D task where an object that is initially on the floor must be transferred to the bin.",
     "variant_description": "The variants require tossing different numbers of objects into the bin.",
-    "variant_specific_description": "Toss one cube into the bin from beyond the robot's reachable distance.",
+    "variant_specific_description": "Get one cube into the bin.",
     "robots": {
         "tidybot": {
             "robot": {}

--- a/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o2.json
+++ b/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o2.json
@@ -1,7 +1,7 @@
 {
-    "description": "A 3D task where an object that is initially on the floor must be transferred to the bin. The robot must toss the object into a bin, since it cannot reach the goal position due to an immovable obstacle.",
+    "description": "A 3D task where an object that is initially on the floor must be transferred to the bin.",
     "variant_description": "The variants require tossing different numbers of objects into the bin.",
-    "variant_specific_description": "Toss two cubes into the bin from beyond the robot's reachable distance.",
+    "variant_specific_description": "Get two cubes into the bin.",
     "robots": {
         "tidybot": {
             "robot": {}

--- a/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o2.json
+++ b/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o2.json
@@ -1,6 +1,6 @@
 {
     "description": "A 3D task where an object that is initially on the floor must be transferred to the bin.",
-    "variant_description": "The variants require tossing different numbers of objects into the bin.",
+    "variant_description": "The variants require transferring different numbers of objects to the bin.",
     "variant_specific_description": "Get two cubes into the bin.",
     "robots": {
         "tidybot": {

--- a/src/kinder/envs/kinematic2d/motion2d.py
+++ b/src/kinder/envs/kinematic2d/motion2d.py
@@ -1,4 +1,4 @@
-"""Environment where only 2D motion planning is needed to reach a goal region."""
+"""Environment where the goal is to reach a target region."""
 
 from dataclasses import dataclass
 
@@ -115,7 +115,7 @@ class Motion2DEnvConfig(Kinematic2DRobotEnvConfig, metaclass=FinalConfigMeta):
 
 
 class ObjectCentricMotion2DEnv(ObjectCentricKinematic2DRobotEnv[Motion2DEnvConfig]):
-    """Only 2D motion planning is needed to reach a goal region.
+    """Environment where the goal is to reach a target region.
 
     This is an object-centric environment. The vectorized version with Box spaces is
     defined below.

--- a/src/kinder/envs/kinematic2d/motion2d.py
+++ b/src/kinder/envs/kinematic2d/motion2d.py
@@ -302,7 +302,7 @@ class Motion2DEnv(ConstantObjectKinDEREnv):
 
 There may be narrow passages.
         
-The robot has a movable circular base and a retractable arm with a rectangular vacuum end effector. The arm and vacuum do not need to be used in this environment.
+The robot has a movable circular base and a retractable arm with a rectangular vacuum end effector.
 """
 
     def _create_variant_markdown_description(self) -> str:

--- a/src/kinder/envs/kinematic2d/pushpullhook2d.py
+++ b/src/kinder/envs/kinematic2d/pushpullhook2d.py
@@ -138,11 +138,7 @@ class ObjectCentricPushPullHook2DEnv(
 ):
     """Environment with a hook, a movable button and a target button.
 
-    The robot or hook cannot directly press the target button.
-
-    The robot can grab the hook and then use it to move the movable button towards the
-    target button. The target button is pressed only when the movable button is in
-    contact with it.
+    The target button is pressed only when the movable button is in contact with it.
     """
 
     def __init__(

--- a/src/kinder/envs/kinematic2d/pushpullhook2d.py
+++ b/src/kinder/envs/kinematic2d/pushpullhook2d.py
@@ -461,7 +461,7 @@ class PushPullHook2DEnv(ConstantObjectKinDEREnv):
             "A 2D environment with a robot, a hook (L-shape), a movable button, "
             "and a target button. "
             "The goal is to move the movable button onto the target button. "
-            "The robot has a movable circular base and a retractable arm with a rectangular vacuum end effector. "
+            "The robot has a movable circular base and a retractable arm with a rectangular vacuum end effector. " # pylint: disable=line-too-long
             "Objects can be grasped and ungrasped when the end effector makes contact."
         )
 

--- a/src/kinder/envs/kinematic2d/pushpullhook2d.py
+++ b/src/kinder/envs/kinematic2d/pushpullhook2d.py
@@ -463,9 +463,9 @@ class PushPullHook2DEnv(ConstantObjectKinDEREnv):
     def _create_env_markdown_description(self) -> str:
         return (
             "A 2D environment with a robot, a hook (L-shape), a movable button, "
-            "and a target button."
-            "The goal is to move the movable button onto the target button."
-            "The robot has a movable circular base and a retractable arm with a rectangular vacuum end effector.",
+            "and a target button. "
+            "The goal is to move the movable button onto the target button. "
+            "The robot has a movable circular base and a retractable arm with a rectangular vacuum end effector. "
             "Objects can be grasped and ungrasped when the end effector makes contact."
         )
 

--- a/src/kinder/envs/kinematic2d/pushpullhook2d.py
+++ b/src/kinder/envs/kinematic2d/pushpullhook2d.py
@@ -464,10 +464,9 @@ class PushPullHook2DEnv(ConstantObjectKinDEREnv):
         return (
             "A 2D environment with a robot, a hook (L-shape), a movable button, "
             "and a target button."
-            "The robot can use the hook to push the movable button towards "
-            "the target button. "
-            "The movable button only moves if the hook is in contact and "
-            "the robot moves in the direction of contact."
+            "The goal is to move the movable button onto the target button."
+            "The robot has a movable circular base and a retractable arm with a rectangular vacuum end effector.",
+            "Objects can be grasped and ungrasped when the end effector makes contact."
         )
 
     def _create_variant_markdown_description(self) -> str:

--- a/src/kinder/envs/kinematic2d/stickbutton2d.py
+++ b/src/kinder/envs/kinematic2d/stickbutton2d.py
@@ -109,11 +109,6 @@ class ObjectCentricStickButton2DEnv(
 ):
     """Environment with a stick and buttons that need to be pressed.
 
-    The robot cannot directly press buttons that are on the table but can directly press
-    buttons that are on the floor (by touching them).
-
-    The stick can be used to press buttons on the table (by touch).
-
     This is an object-centric environment. The vectorized version with Box spaces is
     defined below.
     """

--- a/src/kinder/envs/kinematic2d/stickbutton2d.py
+++ b/src/kinder/envs/kinematic2d/stickbutton2d.py
@@ -361,11 +361,11 @@ class StickButton2DEnv(ConstantObjectKinDEREnv):
     def _create_env_markdown_description(self) -> str:
         num_buttons = len(self._constant_objects) - 2
         # pylint: disable=line-too-long
-        return f"""A 2D environment where the goal is to touch all buttons, possibly by using a stick for buttons that are out of the robot's direct reach.
+        return f"""A 2D environment where the goal is to touch all buttons.
 
 In this environment, there are always {num_buttons} buttons.
 
-The robot has a movable circular base and a retractable arm with a rectangular vacuum end effector.
+The robot has a movable circular base and a retractable arm with a rectangular vacuum end effector. Objects can be grasped and ungrasped when the end effector makes contact.
 """
 
     def _create_variant_markdown_description(self) -> str:

--- a/src/kinder/envs/kinematic3d/base_motion3d.py
+++ b/src/kinder/envs/kinematic3d/base_motion3d.py
@@ -1,4 +1,4 @@
-"""Environment where only base motion is required to reach some goal."""
+"""Environment where the goal is to reach a target region."""
 
 from __future__ import annotations
 
@@ -62,7 +62,7 @@ class ObjectCentricBaseMotion3DEnv(
         BaseMotion3DObjectCentricState, BaseMotion3DEnvConfig
     ]
 ):
-    """Environment where only base motion planning is needed to reach a goal."""
+    """Environment where the goal is to reach a target region."""
 
     def __init__(
         self, config: BaseMotion3DEnvConfig = BaseMotion3DEnvConfig(), **kwargs

--- a/src/kinder/envs/kinematic3d/base_motion3d.py
+++ b/src/kinder/envs/kinematic3d/base_motion3d.py
@@ -189,7 +189,7 @@ class BaseMotion3DEnv(ConstantObjectKinDEREnv):
     def _create_env_markdown_description(self) -> str:
         """Create environment description."""
         # pylint: disable=line-too-long
-        return """A very simple environment where only base motion planning is needed to reach a goal."""
+        return """A simple 3D environment where the goal is to navigate to a target region."""
 
     def _create_variant_markdown_description(self) -> str:
         # pylint: disable=line-too-long

--- a/src/kinder/envs/kinematic3d/motion3d.py
+++ b/src/kinder/envs/kinematic3d/motion3d.py
@@ -1,4 +1,4 @@
-"""Environment where only 3D motion planning is needed to reach a goal region."""
+"""Environment where the goal is to reach a target region."""
 
 from __future__ import annotations
 
@@ -61,7 +61,7 @@ class Motion3DObjectCentricState(Kinematic3DObjectCentricState):
 class ObjectCentricMotion3DEnv(
     ObjectCentricKinematic3DRobotEnv[Motion3DObjectCentricState, Motion3DEnvConfig]
 ):
-    """Environment where only 3D motion planning is needed to reach a goal region."""
+    """Environment where the goal is to reach a target region."""
 
     def __init__(
         self, config: Motion3DEnvConfig = Motion3DEnvConfig(), **kwargs

--- a/src/kinder/envs/kinematic3d/motion3d.py
+++ b/src/kinder/envs/kinematic3d/motion3d.py
@@ -174,7 +174,7 @@ class Motion3DEnv(ConstantObjectKinDEREnv):
         # pylint: disable=line-too-long
         config = self._object_centric_env.config
         assert isinstance(config, Motion3DEnvConfig)
-        return f"""A 3D motion planning environment where the goal is to reach a target sphere with the robot's end effector.
+        return f"""A 3D environment where the goal is to reach a target sphere.
 
 The robot is a Kinova Gen-3 with 7 degrees of freedom. The target is a sphere with radius {config.target_radius:.3f}m positioned randomly within the workspace bounds.
 
@@ -182,8 +182,6 @@ The workspace bounds are:
 - X: [{config.target_lower_bound[0]:.1f}, {config.target_upper_bound[0]:.1f}]
 - Y: [{config.target_lower_bound[1]:.1f}, {config.target_upper_bound[1]:.1f}]
 - Z: [{config.target_lower_bound[2]:.1f}, {config.target_upper_bound[2]:.1f}]
-
-Only targets that are reachable via inverse kinematics are sampled.
 """
 
     def _create_variant_markdown_description(self) -> str:

--- a/src/kinder/envs/kinematic3d/obstruction3d.py
+++ b/src/kinder/envs/kinematic3d/obstruction3d.py
@@ -1,4 +1,4 @@
-"""Environment where obstructions must be cleared to place a target on a region."""
+"""Environment where the goal is to place a target on a region."""
 
 from __future__ import annotations
 
@@ -146,7 +146,7 @@ class ObjectCentricObstruction3DEnv(
         Obstruction3DObjectCentricState, Obstruction3DEnvConfig
     ]
 ):
-    """Environment where obstructions must be cleared to place a target on a region."""
+    """Environment where the goal is to place a target on a region."""
 
     def __init__(
         self,

--- a/src/kinder/envs/kinematic3d/obstruction3d.py
+++ b/src/kinder/envs/kinematic3d/obstruction3d.py
@@ -458,17 +458,15 @@ class Obstruction3DEnv(ConstantObjectKinDEREnv):
         # pylint: disable=line-too-long
         config = self._object_centric_env.config
         assert isinstance(config, Obstruction3DEnvConfig)
-        return f"""A 3D obstruction clearance environment where the goal is to place a target block on a designated target region by first clearing obstructions.
+        return f"""A 3D obstruction clearance environment where the goal is to place a target block on a designated target region, which may be initially obstructed.
 
 The robot is a Kinova Gen-3 with 7 degrees of freedom that can grasp and manipulate objects. The environment consists of:
 - A **table** with dimensions {config.table_half_extents[0]*2:.3f}m × {config.table_half_extents[1]*2:.3f}m × {config.table_half_extents[2]*2:.3f}m
 - A **target region** (purple block) with random dimensions between {config.target_region_half_extents_lb} and {config.target_region_half_extents_ub} half-extents
 - A **target block** that must be placed on the target region, sized at {config.target_block_size_scale}× the target region's x,y dimensions
-- **Obstruction(s)** (red blocks) that may be placed on or near the target region, blocking access
+- **Obstruction(s)** (red blocks) that may be placed on or near the target region
 
 Obstructions have random dimensions between {config.obstruction_half_extents_lb} and {config.obstruction_half_extents_ub} half-extents. During initialization, there's a {config.obstruction_init_on_target_prob} probability that each obstruction will be placed on the target region, requiring clearance.
-
-The task requires planning to grasp and move obstructions out of the way, then place the target block on the target region.
 """
 
     def _create_variant_markdown_description(self) -> str:
@@ -479,8 +477,8 @@ The task requires planning to grasp and move obstructions out of the way, then p
         if self._num_obstructions == 0:
             return "This variant has no obstructions."
         if self._num_obstructions == 1:
-            return "This variant has 1 obstruction to clear."
-        return f"This variant has {self._num_obstructions} obstructions to clear."
+            return "This variant has 1 obstruction."
+        return f"This variant has {self._num_obstructions} obstructions."
 
     def _create_action_space_markdown_description(self) -> str:
         """Create action space description."""
@@ -508,7 +506,7 @@ The goal is considered reached when:
 
 Support is determined based on contact between the target block and target region, within a small distance threshold (1e-4).
 
-This encourages the robot to efficiently clear obstructions and place the target block while avoiding infinite episodes.
+This encourages the robot to place the target block while avoiding infinite episodes.
 """
 
     def _create_references_markdown_description(self) -> str:

--- a/src/kinder/envs/kinematic3d/packing3d.py
+++ b/src/kinder/envs/kinematic3d/packing3d.py
@@ -823,8 +823,6 @@ The robot is a Kinova Gen-3 with 7 degrees of freedom that can grasp and manipul
 - A **table** with dimensions {config.table_half_extents[0]*2:.3f}m × {config.table_half_extents[1]*2:.3f}m × {config.table_half_extents[2]*2:.3f}m
 - A **rack** (purple) with half-extents {config.rack_half_extents}
 - **Parts** (green) that must be packed into the rack. Parts are sampled with half-extents in {config.part_half_extents_lb} to {config.part_half_extents_ub} and a probability {config.part_triangular_prob} of being triangle-shaped (triangles are represented as triangular prisms with depth {config.part_triangle_depth:.3f}m when used).
-
-The task requires planning to grasp and place each part into the rack while avoiding collisions and ensuring parts are supported by the rack (on the rack and not grasped) at the end.
 """
 
     def _create_variant_markdown_description(self) -> str:

--- a/src/kinder/envs/kinematic3d/packing3d.py
+++ b/src/kinder/envs/kinematic3d/packing3d.py
@@ -866,5 +866,5 @@ This encourages the robot to efficiently pack the parts into the rack while avoi
     def _create_references_markdown_description(self) -> str:
         """Create references description."""
         # pylint: disable=line-too-long
-        return """Packing tasks are common in robotics and automated warehousing literature. This environment is inspired by standard manipulation benchmarks and simple bin-packing problems; it’s intended as a deterministic, physics-based testbed for pick-and-place planning and task-and-motion planning approaches.
+        return """Packing tasks are common in robotics and automated warehousing literature. This environment is inspired by standard manipulation benchmarks and simple bin-packing problems; it’s intended as a deterministic, physics-based testbed.
 """


### PR DESCRIPTION
Went through all envs manually and removed every instance I found where a string was giving hints not just about how the env works but how to solve it. This is to ensure any approaches using LLMs to solve the environments given their code can't cheat by already knowing what to do. Hopefully I caught everything but there may be leftovers.

One big thing is that there is still definitely some aspect of this in the code itself, e.g. the class name ("PushPullHook") already implies what to do, and similarly comments and variables can probably inform the agent (e.g. if stuff is mentioning "the hook" and "moving the button" it's already implying how to solve this). But this does not seem fixable to me, and it's a thin line. At least this removes all blatant examples from the descriptions and an agent has to discover this stuff on its own.

After doing this manually I also had claude check and it didn't find anything.