### PR TITLE
Derive FR3 mount_height from table fixture instead of a duplicate literal

### DIFF
--- a/src/kinder/envs/dynamic3d/envs.py
+++ b/src/kinder/envs/dynamic3d/envs.py
@@ -149,10 +149,11 @@ class ObjectCentricRobotEnv(ObjectCentricDynamic3DRobotEnv[TidyBot3DConfig]):
         # Robot-specific settings from the task config (e.g. mount_height)
         # are forwarded as keyword arguments.
         robot_config = self.task_config["robots"][self.robot_type][self.robot_name]
-        if "mount_surface" in robot_config:
-            # Derive mount_height from the referenced table fixture's height
-            # instead of requiring a separately-maintained literal, so the
-            # two can't drift out of sync.
+        if self.robot_type == "fr3" and "mount_surface" in robot_config:
+            # The FR3 is the only fixed-base robot: derive its mount_height
+            # from the referenced table fixture's height instead of
+            # requiring a separately-maintained literal, so the two can't
+            # drift out of sync.
             robot_config = dict(robot_config)
             mount_surface = robot_config.pop("mount_surface")
             table_fixtures = self.task_config.get("fixtures", {}).get("table", {})

--- a/src/kinder/envs/dynamic3d/envs.py
+++ b/src/kinder/envs/dynamic3d/envs.py
@@ -149,6 +149,21 @@ class ObjectCentricRobotEnv(ObjectCentricDynamic3DRobotEnv[TidyBot3DConfig]):
         # Robot-specific settings from the task config (e.g. mount_height)
         # are forwarded as keyword arguments.
         robot_config = self.task_config["robots"][self.robot_type][self.robot_name]
+        if "mount_surface" in robot_config:
+            # Derive mount_height from the referenced table fixture's height
+            # instead of requiring a separately-maintained literal, so the
+            # two can't drift out of sync.
+            robot_config = dict(robot_config)
+            mount_surface = robot_config.pop("mount_surface")
+            table_fixtures = self.task_config.get("fixtures", {}).get("table", {})
+            assert mount_surface in table_fixtures, (
+                f"mount_surface '{mount_surface}' for robot '{self.robot_name}' "
+                f"in task config {task_config_path} is not a table fixture; "
+                f"available table fixtures: {sorted(table_fixtures)}."
+            )
+            robot_config["mount_height"] = float(
+                table_fixtures[mount_surface]["height"]
+            )
         reserved_robot_kwargs = {
             "name",
             "control_frequency",

--- a/src/kinder/envs/dynamic3d/tasks/FrankaPickPlace3D/FrankaPickPlace3D-o1.json
+++ b/src/kinder/envs/dynamic3d/tasks/FrankaPickPlace3D/FrankaPickPlace3D-o1.json
@@ -5,7 +5,7 @@
     "robots": {
         "fr3": {
             "robot": {
-                "mount_height": 0.75
+                "mount_surface": "desk_1"
             }
         }
     },


### PR DESCRIPTION
## Summary

- `robots.fr3.robot.mount_height` and `fixtures.table.desk_1.height` in `FrankaPickPlace3D-o1.json` were two independent hardcoded literals (both happened to be `0.75`) with nothing tying them together.
- Nothing enforced that they stay in sync: if a future task variant changed the desk height without also updating `mount_height`, the FR3 arm would silently be mounted floating above or clipped into the desk, with no error.
- Fix: the robot config now references the table fixture by name (`mount_surface: "desk_1"`) instead of a raw `mount_height` literal. `ObjectCentricRobotEnv.__init__` derives `mount_height` from that fixture's `height` at env-init time, with an assertion if the referenced surface doesn't exist.

## Test plan

- [x] Verified `mount_height` is correctly derived (`0.75`) for the existing `FrankaPickPlace3D-o1` config.
- [x] Verified end-to-end in a mutated copy of the config: changed desk height to `1.10` and confirmed both `robot_env.mount_height` and the actual simulated mount body's z-position in MuJoCo (`body_pos[body_id][2]`) followed the new value.
- [x] `black` / `isort` / `mypy` / `pylint` clean on changed files.
- [x] `pytest tests/envs/dynamic3d/` — 266 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
