### PR TITLE
Fix cluttered retrieval initial-state sampling

### DIFF
--- a/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
+++ b/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
@@ -26,6 +26,7 @@ from kinder.envs.kinematic2d.utils import (
 from kinder.envs.utils import (
     BROWN,
     PURPLE,
+    object_to_multibody2d,
     rectangle_object_to_geom,
     sample_se2_pose,
     state_2d_has_collision,
@@ -204,9 +205,12 @@ class ObjectCentricClutteredRetrieval2DEnv(
             target_block_geom = rectangle_object_to_geom(full_state, target_block, {})
             if geom2ds_intersect(target_block_geom, target_region_geom):
                 continue
-            # Check that target_region doesn't collide with robot or static objects.
-            if state_2d_has_collision(
-                full_state, {target_region}, {robot} | static_objects, {}
+            # Check that the target region does not overlap the robot. This is an
+            # explicit geometric check because goal regions have ZOrder.NONE.
+            robot_multibody = object_to_multibody2d(robot, full_state, {})
+            if any(
+                geom2ds_intersect(target_region_geom, body.geom)
+                for body in robot_multibody.bodies
             ):
                 continue
             # Check that target_block doesn't collide with obstacles.

--- a/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
+++ b/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
@@ -22,7 +22,13 @@ from kinder.envs.kinematic2d.utils import (
     create_walls_from_world_boundaries,
     is_inside,
 )
-from kinder.envs.utils import BROWN, PURPLE, sample_se2_pose, state_2d_has_collision
+from kinder.envs.utils import (
+    BROWN,
+    PURPLE,
+    rectangle_object_to_geom,
+    sample_se2_pose,
+    state_2d_has_collision,
+)
 
 TargetBlockType = Type("target_block", parent=RectangleType)
 TargetRegionType = Type("target_region", parent=RectangleType)
@@ -181,6 +187,18 @@ class ObjectCentricClutteredRetrieval2DEnv(
             target_region = state.get_objects(TargetRegionType)[0]
             full_state = state.copy()
             full_state.data.update(self.initial_constant_state.data)
+            # Check that the full rotated target region is within the world bounds.
+            # Its pose is the bottom-left corner, so constraining only the sampled
+            # x and y coordinates is insufficient when theta is nonzero.
+            target_region_geom = rectangle_object_to_geom(full_state, target_region, {})
+            if any(
+                not (
+                    self.config.world_min_x <= x <= self.config.world_max_x
+                    and self.config.world_min_y <= y <= self.config.world_max_y
+                )
+                for x, y in target_region_geom.vertices
+            ):
+                continue
             # Check that target_region doesn't collide with robot or static objects.
             if state_2d_has_collision(
                 full_state, {target_region}, {robot} | static_objects, {}

--- a/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
+++ b/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import numpy as np
 from relational_structs import Object, ObjectCentricState, Type
 from relational_structs.utils import create_state_from_dict
+from tomsgeoms2d.utils import geom2ds_intersect
 
 from kinder.core import ConstantObjectKinDEREnv, FinalConfigMeta
 from kinder.envs.kinematic2d.base_env import (
@@ -198,6 +199,10 @@ class ObjectCentricClutteredRetrieval2DEnv(
                 )
                 for x, y in target_region_geom.vertices
             ):
+                continue
+            # Check that the target does not start in or overlap its goal region.
+            target_block_geom = rectangle_object_to_geom(full_state, target_block, {})
+            if geom2ds_intersect(target_block_geom, target_region_geom):
                 continue
             # Check that target_region doesn't collide with robot or static objects.
             if state_2d_has_collision(

--- a/tests/envs/kinematic2d/test_clutteredretrieval2d.py
+++ b/tests/envs/kinematic2d/test_clutteredretrieval2d.py
@@ -6,7 +6,9 @@ from gymnasium.wrappers import RecordVideo
 import kinder
 from kinder.envs.kinematic2d.clutteredretrieval2d import (
     ObjectCentricClutteredRetrieval2DEnv,
+    TargetRegionType,
 )
+from kinder.envs.utils import rectangle_object_to_geom
 from tests.conftest import MAKE_VIDEOS
 
 
@@ -34,3 +36,14 @@ def test_clutteredretrieval2d_observation_space():
     for _ in range(5):
         obs, _ = env.reset()
         assert env.observation_space.contains(obs)
+
+
+def test_clutteredretrieval2d_target_region_within_world_bounds():
+    """Tests that the full rotated target region is sampled within the world."""
+    env = ObjectCentricClutteredRetrieval2DEnv(num_obstructions=0)
+    state, _ = env.reset(seed=5)
+    target_region = state.get_objects(TargetRegionType)[0]
+    target_region_geom = rectangle_object_to_geom(state, target_region, {})
+    for x, y in target_region_geom.vertices:
+        assert env.config.world_min_x <= x <= env.config.world_max_x
+        assert env.config.world_min_y <= y <= env.config.world_max_y

--- a/tests/envs/kinematic2d/test_clutteredretrieval2d.py
+++ b/tests/envs/kinematic2d/test_clutteredretrieval2d.py
@@ -10,7 +10,8 @@ from kinder.envs.kinematic2d.clutteredretrieval2d import (
     TargetBlockType,
     TargetRegionType,
 )
-from kinder.envs.utils import rectangle_object_to_geom
+from kinder.envs.kinematic2d.object_types import CRVRobotType
+from kinder.envs.utils import object_to_multibody2d, rectangle_object_to_geom
 from tests.conftest import MAKE_VIDEOS
 
 
@@ -60,3 +61,17 @@ def test_clutteredretrieval2d_target_starts_outside_region():
     target_block_geom = rectangle_object_to_geom(state, target_block, {})
     target_region_geom = rectangle_object_to_geom(state, target_region, {})
     assert not geom2ds_intersect(target_block_geom, target_region_geom)
+
+
+def test_clutteredretrieval2d_target_region_does_not_overlap_robot():
+    """Tests that the target region does not initially overlap the robot."""
+    env = ObjectCentricClutteredRetrieval2DEnv(num_obstructions=0)
+    state, _ = env.reset(seed=91)
+    robot = state.get_objects(CRVRobotType)[0]
+    target_region = state.get_objects(TargetRegionType)[0]
+    robot_multibody = object_to_multibody2d(robot, state, {})
+    target_region_geom = rectangle_object_to_geom(state, target_region, {})
+    assert not any(
+        geom2ds_intersect(target_region_geom, body.geom)
+        for body in robot_multibody.bodies
+    )

--- a/tests/envs/kinematic2d/test_clutteredretrieval2d.py
+++ b/tests/envs/kinematic2d/test_clutteredretrieval2d.py
@@ -2,10 +2,12 @@
 
 from gymnasium.spaces import Box
 from gymnasium.wrappers import RecordVideo
+from tomsgeoms2d.utils import geom2ds_intersect
 
 import kinder
 from kinder.envs.kinematic2d.clutteredretrieval2d import (
     ObjectCentricClutteredRetrieval2DEnv,
+    TargetBlockType,
     TargetRegionType,
 )
 from kinder.envs.utils import rectangle_object_to_geom
@@ -47,3 +49,14 @@ def test_clutteredretrieval2d_target_region_within_world_bounds():
     for x, y in target_region_geom.vertices:
         assert env.config.world_min_x <= x <= env.config.world_max_x
         assert env.config.world_min_y <= y <= env.config.world_max_y
+
+
+def test_clutteredretrieval2d_target_starts_outside_region():
+    """Tests that the target does not initially intersect its goal region."""
+    env = ObjectCentricClutteredRetrieval2DEnv(num_obstructions=0)
+    state, _ = env.reset(seed=54)
+    target_block = state.get_objects(TargetBlockType)[0]
+    target_region = state.get_objects(TargetRegionType)[0]
+    target_block_geom = rectangle_object_to_geom(state, target_block, {})
+    target_region_geom = rectangle_object_to_geom(state, target_region, {})
+    assert not geom2ds_intersect(target_block_geom, target_region_geom)


### PR DESCRIPTION
Fix three ineffective initial-state checks in ClutteredRetrieval2D without changing shared collision semantics:

- keep the full rotated target region within world bounds
- prevent the target from starting in or overlapping its goal
- prevent the goal region from overlapping the robot

Adds one deterministic regression test for each case. The full kinematic-2D test suite passes, and a 2,000-seed sweep found no remaining occurrences.