### PR TITLE
Validate Kinematic3D action bounds and motion paths

### DIFF
--- a/src/kinder/envs/kinematic3d/base_env.py
+++ b/src/kinder/envs/kinematic3d/base_env.py
@@ -80,8 +80,7 @@ class Kinematic3DEnvConfig(KinDEREnvConfig):
     end_effector_viz_half_extents: tuple[float, float, float] = (0.01, 0.01, 0.035)
     end_effector_viz_color: tuple[float, float, float, float] = (1.0, 0.2, 0.2, 0.0)
     max_action_mag: float = 0.4
-    # Maximum coordinate increment between swept-motion collision checks. When unset,
-    # only the action endpoint is checked, preserving the original transition.
+    # None disables intermediate collision checks.
     max_collision_check_step: float | None = None
     check_base_collisions: bool = False
 
@@ -527,9 +526,6 @@ class ObjectCentricKinematic3DRobotEnv(
             self.config.max_action_mag,
         )
         current_base_pose = self.robot.get_base()
-        next_base_pose = current_base_pose + SE2Pose(
-            base_action[0], base_action[1], base_action[2]
-        )
 
         # Store the current robot joints because we may need to revert in collision.
         current_joints = remove_fingers_from_extended_joints(
@@ -551,10 +547,7 @@ class ObjectCentricKinematic3DRobotEnv(
             self._robot_arm.joint_lower_limits[:7],
             self._robot_arm.joint_upper_limits[:7],
         ).tolist()
-        # Apply the motion incrementally so that an action cannot tunnel through a
-        # collision and end at a collision-free configuration. This remains a purely
-        # kinematic transition: intermediate states are used only for validity
-        # checking, with no physics integration or contact response.
+        # Validate the action path at evenly spaced configurations.
         max_delta = max(
             np.max(np.abs(base_action)),
             np.max(np.abs(np.asarray(next_joints) - np.asarray(current_joints))),

--- a/src/kinder/envs/kinematic3d/base_env.py
+++ b/src/kinder/envs/kinematic3d/base_env.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+import math
 from dataclasses import dataclass, field
 from typing import Any, Generic
 from typing import Type as TypingType
@@ -79,6 +80,9 @@ class Kinematic3DEnvConfig(KinDEREnvConfig):
     end_effector_viz_half_extents: tuple[float, float, float] = (0.01, 0.01, 0.035)
     end_effector_viz_color: tuple[float, float, float, float] = (1.0, 0.2, 0.2, 0.0)
     max_action_mag: float = 0.4
+    # Maximum coordinate increment between swept-motion collision checks. When unset,
+    # only the action endpoint is checked, preserving the original transition.
+    max_collision_check_step: float | None = None
     check_base_collisions: bool = False
 
     # This is used to check whether a grasped object can be placed on a surface.
@@ -517,7 +521,11 @@ class ObjectCentricKinematic3DRobotEnv(
 
     def step(self, action: Array) -> tuple[_ObsType, float, bool, bool, dict]:
         # execute the base action
-        base_action = action[:3]
+        base_action = np.clip(
+            action[:3],
+            -self.config.max_action_mag,
+            self.config.max_action_mag,
+        )
         current_base_pose = self.robot.get_base()
         next_base_pose = current_base_pose + SE2Pose(
             base_action[0], base_action[1], base_action[2]
@@ -543,13 +551,42 @@ class ObjectCentricKinematic3DRobotEnv(
             self._robot_arm.joint_lower_limits[:7],
             self._robot_arm.joint_upper_limits[:7],
         ).tolist()
-        self._set_robot_and_held_object(
-            next_base_pose, next_joints, current_finger_state
+        # Apply the motion incrementally so that an action cannot tunnel through a
+        # collision and end at a collision-free configuration. This remains a purely
+        # kinematic transition: intermediate states are used only for validity
+        # checking, with no physics integration or contact response.
+        max_delta = max(
+            np.max(np.abs(base_action)),
+            np.max(np.abs(np.asarray(next_joints) - np.asarray(current_joints))),
         )
+        if self.config.max_collision_check_step is None:
+            num_collision_checks = 1
+        else:
+            if self.config.max_collision_check_step <= 0:
+                raise ValueError("max_collision_check_step must be positive")
+            num_collision_checks = max(
+                1, math.ceil(max_delta / self.config.max_collision_check_step)
+            )
+        motion_valid = True
+        for i in range(1, num_collision_checks + 1):
+            t = i / num_collision_checks
+            intermediate_base_pose = current_base_pose + SE2Pose(
+                t * base_action[0], t * base_action[1], t * base_action[2]
+            )
+            intermediate_joints = (
+                np.asarray(current_joints)
+                + t * (np.asarray(next_joints) - np.asarray(current_joints))
+            ).tolist()
+            self._set_robot_and_held_object(
+                intermediate_base_pose,
+                intermediate_joints,
+                current_finger_state,
+            )
+            if self._robot_or_held_object_collision_exists():
+                motion_valid = False
+                break
 
-        # Check for collisions.
-        if self._robot_or_held_object_collision_exists():
-            # Revert!
+        if not motion_valid:
             self._set_robot_and_held_object(
                 current_base_pose, current_joints, current_finger_state
             )

--- a/tests/envs/kinematic3d/test_base_motion3d.py
+++ b/tests/envs/kinematic3d/test_base_motion3d.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from gymnasium.wrappers import RecordVideo
 from pybullet_helpers.motion_planning import (
+    remap_se2_pose_plan_to_constant_distance,
     run_single_arm_mobile_base_motion_planning,
 )
 from relational_structs.spaces import ObjectCentricBoxSpace
@@ -13,6 +14,7 @@ from relational_structs.spaces import ObjectCentricBoxSpace
 import kinder
 from kinder.envs.kinematic3d.base_motion3d import (
     BaseMotion3DEnv,
+    BaseMotion3DEnvConfig,
     BaseMotion3DObjectCentricState,
     ObjectCentricBaseMotion3DEnv,
 )
@@ -40,6 +42,33 @@ def test_base_motion3d_env(env):  # pylint: disable=redefined-outer-name
         act = env.action_space.sample()
         assert isinstance(act, np.ndarray)
         obs, _, _, _, _ = env.step(act)
+
+
+def test_standard_action_magnitude_and_base_action_clipping():
+    """Base and arm deltas use the environment's configured action magnitude."""
+    config = BaseMotion3DEnvConfig(max_action_mag=0.2)
+    environment = BaseMotion3DEnv(config=config, use_gui=False, realistic_bg=False)
+    try:
+        vec_obs, _ = environment.reset(seed=123)
+        assert np.all(environment.action_space.low[:10] == -0.2)
+        assert np.all(environment.action_space.high[:10] == 0.2)
+
+        initial_obs = environment.observation_space.devectorize(vec_obs)
+        initial_state = BaseMotion3DObjectCentricState(
+            initial_obs.data, initial_obs.type_features
+        )
+        out_of_range_action = np.array(
+            [1.0, 0.0, 0.0] + [0.0] * 7 + [0.0], dtype=np.float32
+        )
+        next_vec_obs, _, _, _, _ = environment.step(out_of_range_action)
+        next_obs = environment.observation_space.devectorize(next_vec_obs)
+        next_state = BaseMotion3DObjectCentricState(
+            next_obs.data, next_obs.type_features
+        )
+
+        assert np.isclose(next_state.base_pose.x - initial_state.base_pose.x, 0.2)
+    finally:
+        environment.close()
 
     # Uncomment to debug.
     # import pybullet as p
@@ -72,6 +101,9 @@ def test_motion_planning_in_base_motion3d_env(
         seed=123,
     )
     assert base_plan is not None
+    base_plan = remap_se2_pose_plan_to_constant_distance(
+        base_plan, max_distance=config.max_action_mag
+    )
 
     env.action_space.seed(123)
     for target_base_pose in base_plan[1:]:

--- a/tests/envs/kinematic3d/test_packing3d.py
+++ b/tests/envs/kinematic3d/test_packing3d.py
@@ -21,6 +21,7 @@ from kinder.envs.kinematic3d.object_types import Kinematic3DTriangleType
 from kinder.envs.kinematic3d.packing3d import (
     ObjectCentricPacking3DEnv,
     Packing3DEnv,
+    Packing3DEnvConfig,
     Packing3DObjectCentricState,
 )
 from kinder.envs.kinematic3d.save_utils import DEFAULT_DEMOS_DIR, save_demo
@@ -46,6 +47,46 @@ def test_packing3d_env_basic():
             obs, _, _, _, _ = env.step(act)
 
         env.close()
+
+
+def test_packing3d_rejects_collision_tunneling_action() -> None:
+    """A collision-free endpoint is invalid when the swept motion collides."""
+    # Retain the old, larger action bound in this regression to isolate swept
+    # collision validation from the separate standardization to 0.2.
+    env = Packing3DEnv(
+        num_parts=3,
+        config=Packing3DEnvConfig(
+            max_action_mag=0.4,
+            max_collision_check_step=0.05,
+        ),
+        use_gui=False,
+        realistic_bg=False,
+    )
+    obs, _ = env.reset(seed=7138484576005690180)
+
+    # This action reaches a collision-free grasp endpoint in the old transition,
+    # despite the arm passing through a collision along the way.
+    action = np.array(
+        [
+            0.0417,
+            -0.3489,
+            0.0,
+            -0.0018,
+            0.3679,
+            0.0094,
+            0.0146,
+            -0.0002,
+            0.2311,
+            0.0072,
+            -1.0,
+        ],
+        dtype=np.float32,
+    )
+    next_obs, _, _, _, _ = env.step(action)
+
+    assert np.allclose(next_obs[:11], obs[:11])
+    assert np.all(next_obs[[38, 50, 62]] == 0.0)
+    env.close()
 
 
 def test_packing3d_goal():

--- a/tests/envs/kinematic3d/test_packing3d.py
+++ b/tests/envs/kinematic3d/test_packing3d.py
@@ -51,8 +51,6 @@ def test_packing3d_env_basic():
 
 def test_packing3d_rejects_collision_tunneling_action() -> None:
     """A collision-free endpoint is invalid when the swept motion collides."""
-    # Retain the old, larger action bound in this regression to isolate swept
-    # collision validation from the separate standardization to 0.2.
     env = Packing3DEnv(
         num_parts=3,
         config=Packing3DEnvConfig(
@@ -64,8 +62,7 @@ def test_packing3d_rejects_collision_tunneling_action() -> None:
     )
     obs, _ = env.reset(seed=7138484576005690180)
 
-    # This action reaches a collision-free grasp endpoint in the old transition,
-    # despite the arm passing through a collision along the way.
+    # The arm crosses a collision before reaching a collision-free endpoint.
     action = np.array(
         [
             0.0417,

--- a/tests/envs/kinematic3d/test_prpl3d.py
+++ b/tests/envs/kinematic3d/test_prpl3d.py
@@ -10,6 +10,7 @@ from pybullet_helpers.geometry import Pose, SE2Pose
 from pybullet_helpers.motion_planning import (
     create_joint_distance_fn,
     remap_joint_position_plan_to_constant_distance,
+    remap_se2_pose_plan_to_constant_distance,
     run_motion_planning,
     run_single_arm_mobile_base_motion_planning,
     run_smooth_motion_planning_to_pose,
@@ -165,6 +166,9 @@ def test_pick_place(env):  # pylint: disable=redefined-outer-name
         seed=123,
     )
     assert base_plan is not None
+    base_plan = remap_se2_pose_plan_to_constant_distance(
+        base_plan, max_distance=config.max_action_mag
+    )
     obs = _execute_base_plan(env, base_plan, obs)
 
     # Step 2: Move arm to pre-grasp pose.
@@ -243,6 +247,9 @@ def test_pick_place(env):  # pylint: disable=redefined-outer-name
         seed=456,
     )
     assert base_plan is not None
+    base_plan = remap_se2_pose_plan_to_constant_distance(
+        base_plan, max_distance=config.max_action_mag
+    )
     obs = _execute_base_plan(env, base_plan, obs)
 
     # Step 7: Place cube on counter surface.

--- a/tests/envs/kinematic3d/test_shelf3d.py
+++ b/tests/envs/kinematic3d/test_shelf3d.py
@@ -10,6 +10,7 @@ from pybullet_helpers.geometry import Pose, SE2Pose
 from pybullet_helpers.motion_planning import (
     create_joint_distance_fn,
     remap_joint_position_plan_to_constant_distance,
+    remap_se2_pose_plan_to_constant_distance,
     run_motion_planning,
     run_single_arm_mobile_base_motion_planning,
     run_smooth_motion_planning_to_pose,
@@ -180,6 +181,9 @@ def test_pick_place(env):  # pylint: disable=redefined-outer-name
         seed=123,
     )
     assert base_plan is not None
+    base_plan = remap_se2_pose_plan_to_constant_distance(
+        base_plan, max_distance=config.max_action_mag
+    )
     obs = _execute_base_plan(env, base_plan, obs)
 
     # Step 2: Move arm to pre-grasp pose and then to grasp pose
@@ -267,6 +271,9 @@ def test_pick_place(env):  # pylint: disable=redefined-outer-name
         seed=456,
     )
     assert base_plan is not None
+    base_plan = remap_se2_pose_plan_to_constant_distance(
+        base_plan, max_distance=config.max_action_mag
+    )
     obs = _execute_base_plan(env, base_plan, obs)
 
     # Step 7: Move arm to place the cube on the first shelf layer

--- a/tests/envs/kinematic3d/test_table3d.py
+++ b/tests/envs/kinematic3d/test_table3d.py
@@ -10,6 +10,7 @@ from pybullet_helpers.geometry import Pose, SE2Pose
 from pybullet_helpers.motion_planning import (
     create_joint_distance_fn,
     remap_joint_position_plan_to_constant_distance,
+    remap_se2_pose_plan_to_constant_distance,
     run_single_arm_mobile_base_motion_planning,
     smoothly_follow_end_effector_path,
 )
@@ -112,6 +113,9 @@ def test_goal_reached_after_pick(env) -> None:  # pylint: disable=redefined-oute
         seed=123,
     )
     assert base_plan is not None
+    base_plan = remap_se2_pose_plan_to_constant_distance(
+        base_plan, max_distance=config.max_action_mag
+    )
 
     for target_base_pose in base_plan[1:]:
         current_base_pose = obs.base_pose

--- a/tests/envs/kinematic3d/test_transport3d.py
+++ b/tests/envs/kinematic3d/test_transport3d.py
@@ -8,6 +8,7 @@ from pybullet_helpers.geometry import Pose, SE2Pose
 from pybullet_helpers.motion_planning import (
     create_joint_distance_fn,
     remap_joint_position_plan_to_constant_distance,
+    remap_se2_pose_plan_to_constant_distance,
     run_motion_planning,
     run_single_arm_mobile_base_motion_planning,
     smoothly_follow_end_effector_path,
@@ -111,6 +112,9 @@ def test_pick_place_after_moving(env):  # pylint: disable=redefined-outer-name
         seed=123,
     )
     assert base_plan is not None
+    base_plan = remap_se2_pose_plan_to_constant_distance(
+        base_plan, max_distance=config.max_action_mag
+    )
 
     for target_base_pose in base_plan[1:]:
         current_base_pose = obs.base_pose
@@ -229,6 +233,9 @@ def test_pick_place_after_moving(env):  # pylint: disable=redefined-outer-name
         seed=123,
     )
     assert base_plan is not None
+    base_plan = remap_se2_pose_plan_to_constant_distance(
+        base_plan, max_distance=config.max_action_mag
+    )
 
     for target_base_pose in base_plan[1:]:
         current_base_pose = obs.base_pose


### PR DESCRIPTION
## Summary

This PR makes the Kinematic3D transition contract enforceable and reusable:

- clip mobile-base deltas to `max_action_mag`, matching the arm-joint clipping and declared action space;
- add an optional `max_collision_check_step` configuration for validating the interpolated path between the current and proposed configurations;
- reject the complete motion when the robot or a held object collides at an intermediate configuration; and
- update planner-backed tests to subdivide base paths into actions that respect the configured bound.

The swept check is disabled by default. Individual environments can opt in at a resolution appropriate for their geometry.

## Motivation

Kinematic3D previously checked only the endpoint of each action. It also applied the three mobile-base deltas without clipping them, even though those dimensions are bounded by `max_action_mag` in the action space. A caller could therefore submit an out-of-range base displacement, and an otherwise in-range action could move the robot or a grasped object through geometry as long as the endpoint was collision-free.

Packing3D makes this especially visible because its sources and destination are close together. The trajectory below solves a three-part instance in the theoretical minimum of six actions. Dense replay of the accepted actions finds collisions at intermediate configurations.

![Packing3D endpoint-only trajectory](https://raw.githubusercontent.com/merlerm/kindergarden/pr-assets-kinder3d-fixes/docs/pr-assets/kinder3d-fixes/packing-before.gif)

This is a transition-validity issue rather than a reward issue. The sparse reward favors short solutions, but it should not make collision-crossing actions valid.

## Corrected behavior

The environment layers above this PR opt into the shared validator and retain sparse rewards. Their corrected trajectories use bounded, collision-valid actions:

| Packing3D | Obstruction3D |
| --- | --- |
| ![Packing3D corrected behavior](https://raw.githubusercontent.com/merlerm/kindergarden/pr-assets-kinder3d-fixes/docs/pr-assets/kinder3d-fixes/packing-after.gif) | ![Obstruction3D corrected behavior](https://raw.githubusercontent.com/merlerm/kindergarden/pr-assets-kinder3d-fixes/docs/pr-assets/kinder3d-fixes/obstruction-after-detailed.gif) |

The Packing3D recording uses the same seed as the six-action trajectory above and completes in 89 actions under #138. The Obstruction3D recording is the repository demo regenerated under #137: eight in-space actions, no rejected motions, and terminal success. These are feasibility demonstrations of the opt-in environment layers; this base PR supplies the reusable transition mechanism.

## Transition semantics

When `max_collision_check_step` is set, the environment subdivides the clipped action so that no interpolated coordinate changes by more than the configured amount. It checks the same robot and held-object collision conditions at each sample. If any sample is invalid, the robot and held object return to their starting poses.

Gripper commands retain their existing semantics: the open or close command is processed after the motion is accepted or reverted, so moving and operating the gripper in one action remains supported.

## Compatibility

- Existing environments keep endpoint-only checking unless they opt in.
- Rewards and termination conditions are unchanged.
- In-bound endpoint-valid actions behave as before when swept checking is disabled.

## Test plan

- Shared-layer Kinematic3D regression suite: **16 passed**.
- Exact CI-style pylint check for `base_env.py`: **passed**.
- Added a regression that verifies an oversized base command is clipped to the configured bound.
- Added a regression that reaches a collision-free endpoint through an invalid path and verifies that swept validation rejects it.
- Updated planner-derived test trajectories so each base action respects `max_action_mag`.

## Stack

This is the bottom layer of native stack #139.
