### PR TITLE
Prevent Transport3D reset objects from overlapping the table

### DIFF
--- a/src/kinder/envs/kinematic3d/transport3d.py
+++ b/src/kinder/envs/kinematic3d/transport3d.py
@@ -280,7 +280,7 @@ class ObjectCentricTransport3DEnv(
             ),
             physics_client_id=self.physics_client_id,
             rng=self.np_random,
-            other_collision_ids={self.robot.base.robot_id},
+            other_collision_ids={self.robot.base.robot_id, self.table_id},
         )
 
         sample_collision_free_object_poses(
@@ -302,7 +302,7 @@ class ObjectCentricTransport3DEnv(
             ),
             physics_client_id=self.physics_client_id,
             rng=self.np_random,
-            other_collision_ids=box_ids | {self.robot.base.robot_id},
+            other_collision_ids=box_ids | {self.robot.base.robot_id, self.table_id},
         )
 
     def _set_object_states(self, obs: Kinematic3DObjectCentricState) -> None:

--- a/tests/envs/kinematic3d/test_transport3d.py
+++ b/tests/envs/kinematic3d/test_transport3d.py
@@ -287,3 +287,28 @@ def test_pick_place_after_moving(env):  # pylint: disable=redefined-outer-name
         obs = Transport3DObjectCentricState(oc_obs.data, oc_obs.type_features)
 
     assert obs.grasped_object is None, "Object not released"
+
+
+def _get_aabb(obs, object_name):
+    """Axis-aligned bounding box (lower, upper) of an object in the state."""
+    center = np.array(obs.get_object_pose(object_name).position)
+    half_extents = np.array(obs.get_object_half_extents(object_name))
+    return center - half_extents, center + half_extents
+
+
+def test_reset_objects_avoid_table(env):  # pylint: disable=redefined-outer-name
+    """Reset samples do not penetrate the table."""
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    for seed in [57, 97, 148]:
+        vec_obs, _ = env.reset(seed=seed)
+        oc_obs = env.observation_space.devectorize(vec_obs)
+        obs = Transport3DObjectCentricState(oc_obs.data, oc_obs.type_features)
+        table_lo, table_hi = _get_aabb(obs, "table")
+        for obj in obs:
+            if not (obj.name.startswith("cube") or obj.name.startswith("box")):
+                continue
+            lo, hi = _get_aabb(obs, obj.name)
+            overlap = np.minimum(hi, table_hi) - np.maximum(lo, table_lo)
+            assert (
+                overlap.min() <= 1e-6
+            ), f"{obj.name} intersects the table after reset(seed={seed})"


### PR DESCRIPTION
## Summary

This PR includes the table in Transport3D's movable-object collision checks during reset sampling. Both the transport box and source cubes are now rejected when their sampled geometry overlaps the table.

## Motivation

The reset bounds include space occupied by the fixed table, but the table was absent from the collision set used to validate sampled movable-object poses. This could initialize the box or a cube inside the table. Such states are invalid independently of the policy: they can be infeasible, or they can encourage one-step extraction motions that exploit the initial overlap.

The table is part of the environment's fixed obstacle geometry, so reset sampling should treat its occupied volume the same way it treats the other collision bodies.

## What changed

- Add the table body to the collision IDs used while sampling the transport box.
- Add the table body to the collision IDs used while sampling each cube.
- Add deterministic regressions for seeds that previously produced table overlap.

This PR does not change the reward, goal predicate, action scale, or nominal task distribution. It only removes invalid samples from that distribution.

## Test plan

- Focused Transport3D suite: **3 passed**.
- Regression seeds `57`, `97`, and `148` verify that neither the box nor any cube has positive-volume AABB overlap with the table after reset.

## Stack

Second layer of native stack #139. Depends on #135.
