### PR TITLE
Validate Packing3D motion, state, and geometry

### DIFF
--- a/src/kinder/envs/kinematic3d/packing3d.py
+++ b/src/kinder/envs/kinematic3d/packing3d.py
@@ -47,6 +47,7 @@ class Packing3DEnvConfig(Kinematic3DEnvConfig, metaclass=FinalConfigMeta):
     """Config for Packing3DEnv()."""
 
     # Robot.
+    max_action_mag: float = 0.2
     robot_base_home_pose: SE2Pose = SE2Pose(-0.12, 0, 0)
     robot_base_z: float = -0.4
 
@@ -798,16 +799,62 @@ class ObjectCentricPacking3DEnv(
         return state
 
     def goal_reached(self) -> bool:
-        # Goal: no parts are grasped and all parts are supported by the rack.
+        # Goal: no parts are grasped and all parts are seated inside the rack cavity.
         if self._grasped_object is not None:
             return False
         obs = self._get_obs()
         for i in range(self._num_parts):
             part_name = f"part{i}"
-            if not obs.is_part_inside_rack(part_name):
+            if not self._part_is_seated_in_rack(part_name, obs):
                 return False
 
         return True
+
+    def _part_is_seated_in_rack(
+        self, part_name: str, obs: Packing3DObjectCentricState
+    ) -> bool:
+        """Check that a part is supported by the floor of the rack cavity."""
+        rack_half_extents = obs.rack_half_extents
+        wall_thickness = self.config.rack_wall_thickness
+        inner_half_extents = (
+            rack_half_extents[0] - wall_thickness,
+            rack_half_extents[1] - wall_thickness,
+            rack_half_extents[2],
+        )
+        rack_inner_polygon = obs._get_box_xy_polygon(  # pylint: disable=protected-access
+            obs.rack_pose, inner_half_extents
+        )
+        part = obs.get_object_from_name(part_name)
+        if part.type == Kinematic3DCuboidType:
+            part_polygon = obs._get_box_xy_polygon(  # pylint: disable=protected-access
+                obs.get_object_pose(part_name),
+                obs.get_object_half_extents_packing3d(part_name)[:3],
+            )
+        else:
+            assert part.type == Kinematic3DTriangleType
+            part_polygon = obs._get_triangle_xy_polygon(  # pylint: disable=protected-access
+                part_name
+            )
+        if not rack_inner_polygon.buffer(1e-9).contains(part_polygon):
+            return False
+
+        part_id = self._object_name_to_pybullet_id(part_name)
+        part_lower, part_upper = p.getAABB(
+            part_id, 0, physicsClientId=self.physics_client_id
+        )
+        rack_floor_z = (
+            obs.rack_pose.position[2]
+            - rack_half_extents[2]
+            + wall_thickness
+        )
+        rack_rim_z = obs.rack_pose.position[2] + rack_half_extents[2]
+        tolerance = self.config.min_placement_dist
+        if not np.isclose(part_lower[2], rack_floor_z, atol=tolerance):
+            return False
+        if part_upper[2] > rack_rim_z + tolerance:
+            return False
+
+        return self._rack_id in self._get_surfaces_supporting_object(part_id)
 
 
 class Packing3DEnv(ConstantObjectKinDEREnv):

--- a/src/kinder/envs/kinematic3d/packing3d.py
+++ b/src/kinder/envs/kinematic3d/packing3d.py
@@ -43,7 +43,7 @@ from kinder.envs.utils import PURPLE
 
 # Dimensions used by pybullet_helpers' part grasp pegs.
 _PART_PEG_HALF_EXTENTS = (0.01, 0.01, 0.025)
-_PENETRATION_TOLERANCE = 1e-6
+_OVERLAP_TOLERANCE = 1e-6
 
 
 @dataclass(frozen=True)
@@ -687,7 +687,7 @@ class ObjectCentricPacking3DEnv(
                         break
                 if not collision_exists:
                     collision_exists = any(
-                        self._parts_penetrate(name, other_name)
+                        self._parts_overlap(name, other_name)
                         for other_name in self._part_ids
                         if other_name != name
                     )
@@ -869,11 +869,11 @@ class ObjectCentricPacking3DEnv(
         return world_components
 
     @staticmethod
-    def _convex_components_penetrate(
+    def _convex_components_overlap(
         first: tuple[np.ndarray, np.ndarray, np.ndarray],
         second: tuple[np.ndarray, np.ndarray, np.ndarray],
     ) -> bool:
-        """Use the separating axis theorem to detect strict 3D penetration."""
+        """Use the separating axis theorem to detect strict 3D overlap."""
         first_vertices, first_normals, first_edges = first
         second_vertices, second_normals, second_edges = second
         candidate_axes = [*first_normals, *second_normals]
@@ -884,7 +884,7 @@ class ObjectCentricPacking3DEnv(
         )
         for axis in candidate_axes:
             norm = np.linalg.norm(axis)
-            if norm <= _PENETRATION_TOLERANCE:
+            if norm <= _OVERLAP_TOLERANCE:
                 continue
             normalized_axis = axis / norm
             first_projection = first_vertices @ normalized_axis
@@ -892,16 +892,16 @@ class ObjectCentricPacking3DEnv(
             overlap = min(first_projection.max(), second_projection.max()) - max(
                 first_projection.min(), second_projection.min()
             )
-            if overlap <= _PENETRATION_TOLERANCE:
+            if overlap <= _OVERLAP_TOLERANCE:
                 return False
         return True
 
-    def _parts_penetrate(self, first_name: str, second_name: str) -> bool:
-        """Check exact part geometry, including pegs, without mesh contact queries."""
+    def _parts_overlap(self, first_name: str, second_name: str) -> bool:
+        """Check part overlap using exact geometry, including grasp pegs."""
         first_components = self._get_part_convex_components(first_name)
         second_components = self._get_part_convex_components(second_name)
         return any(
-            self._convex_components_penetrate(first, second)
+            self._convex_components_overlap(first, second)
             for first in first_components
             for second in second_components
         )
@@ -913,7 +913,7 @@ class ObjectCentricPacking3DEnv(
         if self._grasped_object is None:
             return False
         return any(
-            self._parts_penetrate(self._grasped_object, other_name)
+            self._parts_overlap(self._grasped_object, other_name)
             for other_name in self._part_ids
             if other_name != self._grasped_object
         )
@@ -969,16 +969,16 @@ class ObjectCentricPacking3DEnv(
                 return False
             part_names.append(part_name)
 
-        # Reject penetration between seated parts.
+        # Reject overlap between seated parts.
         for i, part_name in enumerate(part_names):
             for other_part_name in part_names[i + 1 :]:
-                if self._parts_penetrate(part_name, other_part_name):
+                if self._parts_overlap(part_name, other_part_name):
                     return False
 
         return True
 
-    def _bodies_penetrate(self, body1: int, body2: int) -> bool:
-        """Check for penetration while allowing nonpenetrating support contact."""
+    def _bodies_overlap(self, body1: int, body2: int) -> bool:
+        """Check body overlap while allowing support contact."""
         contact_points = p.getClosestPoints(
             body1,
             body2,
@@ -1019,7 +1019,7 @@ class ObjectCentricPacking3DEnv(
         if part_upper_z > rack_rim_z + tolerance:
             return False
 
-        if self._bodies_penetrate(part_id, self._rack_id):
+        if self._bodies_overlap(part_id, self._rack_id):
             return False
 
         return self._rack_id in self._get_surfaces_supporting_object(part_id)

--- a/src/kinder/envs/kinematic3d/packing3d.py
+++ b/src/kinder/envs/kinematic3d/packing3d.py
@@ -41,8 +41,7 @@ from kinder.envs.kinematic3d.utils import (
 )
 from kinder.envs.utils import PURPLE
 
-# Keep these dimensions synchronized with the grasp pegs created by the
-# pybullet_helpers ``*_with_peg`` utilities.
+# Dimensions used by pybullet_helpers' part grasp pegs.
 _PART_PEG_HALF_EXTENTS = (0.01, 0.01, 0.025)
 _PENETRATION_TOLERANCE = 1e-6
 
@@ -908,7 +907,7 @@ class ObjectCentricPacking3DEnv(
         )
 
     def _robot_or_held_object_collision_exists(self) -> bool:
-        """Also validate held-part collisions with exact Packing3D geometry."""
+        """Check analytic collisions for a held part."""
         if super()._robot_or_held_object_collision_exists():
             return True
         if self._grasped_object is None:
@@ -960,7 +959,6 @@ class ObjectCentricPacking3DEnv(
         return state
 
     def goal_reached(self) -> bool:
-        # Goal: no parts are grasped and all parts are seated inside the rack cavity.
         if self._grasped_object is not None:
             return False
         obs = self._get_obs()
@@ -971,8 +969,7 @@ class ObjectCentricPacking3DEnv(
                 return False
             part_names.append(part_name)
 
-        # Containment and support are per-part properties, so check separately that
-        # the packed parts do not penetrate one another.
+        # Reject penetration between seated parts.
         for i, part_name in enumerate(part_names):
             for other_part_name in part_names[i + 1 :]:
                 if self._parts_penetrate(part_name, other_part_name):

--- a/src/kinder/envs/kinematic3d/packing3d.py
+++ b/src/kinder/envs/kinematic3d/packing3d.py
@@ -41,6 +41,11 @@ from kinder.envs.kinematic3d.utils import (
 )
 from kinder.envs.utils import PURPLE
 
+# Keep these dimensions synchronized with the grasp pegs created by the
+# pybullet_helpers ``*_with_peg`` utilities.
+_PART_PEG_HALF_EXTENTS = (0.01, 0.01, 0.025)
+_PENETRATION_TOLERANCE = 1e-6
+
 
 @dataclass(frozen=True)
 class Packing3DEnvConfig(Kinematic3DEnvConfig, metaclass=FinalConfigMeta):
@@ -681,6 +686,12 @@ class ObjectCentricPacking3DEnv(
                     if check_body_collisions(part_id, other_id, self.physics_client_id):
                         collision_exists = True
                         break
+                if not collision_exists:
+                    collision_exists = any(
+                        self._parts_penetrate(name, other_name)
+                        for other_name in self._part_ids
+                        if other_name != name
+                    )
 
                 if not collision_exists:
                     break
@@ -759,6 +770,155 @@ class ObjectCentricPacking3DEnv(
             names.add("rack")
         return names
 
+    @staticmethod
+    def _box_local_geometry(
+        half_extents: tuple[float, float, float],
+        center: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Return vertices, face normals, and edge directions for a local box."""
+        vertices = np.array(
+            [
+                [
+                    center[0] + sx * half_extents[0],
+                    center[1] + sy * half_extents[1],
+                    center[2] + sz * half_extents[2],
+                ]
+                for sx in (-1, 1)
+                for sy in (-1, 1)
+                for sz in (-1, 1)
+            ],
+            dtype=float,
+        )
+        axes = np.eye(3)
+        return vertices, axes, axes
+
+    @staticmethod
+    def _triangle_prism_local_geometry(
+        triangle_type: float,
+        side_a: float,
+        side_b: float,
+        depth: float,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Return convex geometry for an equilateral or right triangular prism."""
+        triangle_vertices = np.asarray(
+            get_triangle_vertices(
+                {0: "equilateral", 1: "right"}[int(triangle_type)],
+                (side_a, side_b),
+            ),
+            dtype=float,
+        )
+        lower = triangle_vertices.copy()
+        upper = triangle_vertices.copy()
+        lower[:, 2] = -depth / 2
+        upper[:, 2] = depth / 2
+        vertices = np.concatenate((lower, upper))
+
+        face_normals = [np.array([0.0, 0.0, 1.0])]
+        edge_directions = [np.array([0.0, 0.0, 1.0])]
+        for index in range(3):
+            edge = triangle_vertices[(index + 1) % 3] - triangle_vertices[index]
+            edge[2] = 0.0
+            edge_directions.append(edge)
+            face_normals.append(np.array([edge[1], -edge[0], 0.0]))
+        return vertices, np.asarray(face_normals), np.asarray(edge_directions)
+
+    def _get_part_convex_components(
+        self, part_name: str
+    ) -> list[tuple[np.ndarray, np.ndarray, np.ndarray]]:
+        """Return the world-frame convex components of a part and its grasp peg."""
+        part_id = self._object_name_to_pybullet_id(part_name)
+        part_type = self._part_ids_to_type[part_id]
+        if part_type == Kinematic3DCuboidType:
+            half_extents = self._part_id_to_half_extents[part_id]
+            main_geometry = self._box_local_geometry(half_extents)
+            peg_center = (0.0, 0.0, half_extents[2] + _PART_PEG_HALF_EXTENTS[2])
+        else:
+            assert part_type == Kinematic3DTriangleType
+            side_a, side_b, depth, triangle_type = self._part_ids_to_triangle_features[
+                part_id
+            ]
+            main_geometry = self._triangle_prism_local_geometry(
+                triangle_type, side_a, side_b, depth
+            )
+            triangle_vertices = np.asarray(
+                get_triangle_vertices(
+                    {0: "equilateral", 1: "right"}[int(triangle_type)],
+                    (side_a, side_b),
+                ),
+                dtype=float,
+            )
+            centroid = np.mean(triangle_vertices, axis=0)
+            peg_center = (
+                float(centroid[0]),
+                float(centroid[1]),
+                depth / 2 + _PART_PEG_HALF_EXTENTS[2],
+            )
+        peg_geometry = self._box_local_geometry(_PART_PEG_HALF_EXTENTS, peg_center)
+
+        pose = get_pose(part_id, self.physics_client_id)
+        rotation = Rotation.from_quat(pose.orientation).as_matrix()
+        translation = np.asarray(pose.position)
+        world_components = []
+        for vertices, face_normals, edge_directions in (main_geometry, peg_geometry):
+            world_components.append(
+                (
+                    (rotation @ vertices.T).T + translation,
+                    (rotation @ face_normals.T).T,
+                    (rotation @ edge_directions.T).T,
+                )
+            )
+        return world_components
+
+    @staticmethod
+    def _convex_components_penetrate(
+        first: tuple[np.ndarray, np.ndarray, np.ndarray],
+        second: tuple[np.ndarray, np.ndarray, np.ndarray],
+    ) -> bool:
+        """Use the separating axis theorem to detect strict 3D penetration."""
+        first_vertices, first_normals, first_edges = first
+        second_vertices, second_normals, second_edges = second
+        candidate_axes = [*first_normals, *second_normals]
+        candidate_axes.extend(
+            np.cross(first_edge, second_edge)
+            for first_edge in first_edges
+            for second_edge in second_edges
+        )
+        for axis in candidate_axes:
+            norm = np.linalg.norm(axis)
+            if norm <= _PENETRATION_TOLERANCE:
+                continue
+            normalized_axis = axis / norm
+            first_projection = first_vertices @ normalized_axis
+            second_projection = second_vertices @ normalized_axis
+            overlap = min(first_projection.max(), second_projection.max()) - max(
+                first_projection.min(), second_projection.min()
+            )
+            if overlap <= _PENETRATION_TOLERANCE:
+                return False
+        return True
+
+    def _parts_penetrate(self, first_name: str, second_name: str) -> bool:
+        """Check exact part geometry, including pegs, without mesh contact queries."""
+        first_components = self._get_part_convex_components(first_name)
+        second_components = self._get_part_convex_components(second_name)
+        return any(
+            self._convex_components_penetrate(first, second)
+            for first in first_components
+            for second in second_components
+        )
+
+    def _robot_or_held_object_collision_exists(self) -> bool:
+        """Also validate held-part collisions with exact Packing3D geometry."""
+        if super()._robot_or_held_object_collision_exists():
+            return True
+        if self._grasped_object is None:
+            return False
+        return any(
+            self._parts_penetrate(self._grasped_object, other_name)
+            for other_name in self._part_ids
+            if other_name != self._grasped_object
+        )
+
     def _get_half_extents(self, object_name: str) -> tuple[float, float, float]:
         if object_name == "rack":
             return self.config.rack_half_extents
@@ -804,19 +964,18 @@ class ObjectCentricPacking3DEnv(
         if self._grasped_object is not None:
             return False
         obs = self._get_obs()
-        part_ids = []
+        part_names = []
         for i in range(self._num_parts):
             part_name = f"part{i}"
             if not self._part_is_seated_in_rack(part_name, obs):
                 return False
-            part_ids.append(self._object_name_to_pybullet_id(part_name))
+            part_names.append(part_name)
 
         # Containment and support are per-part properties, so check separately that
         # the packed parts do not penetrate one another.
-        p.performCollisionDetection(physicsClientId=self.physics_client_id)
-        for i, part_id in enumerate(part_ids):
-            for other_part_id in part_ids[i + 1 :]:
-                if self._bodies_penetrate(part_id, other_part_id):
+        for i, part_name in enumerate(part_names):
+            for other_part_name in part_names[i + 1 :]:
+                if self._parts_penetrate(part_name, other_part_name):
                     return False
 
         return True
@@ -842,37 +1001,25 @@ class ObjectCentricPacking3DEnv(
             rack_half_extents[1] - wall_thickness,
             rack_half_extents[2],
         )
-        rack_inner_polygon = obs._get_box_xy_polygon(  # pylint: disable=protected-access
-            obs.rack_pose, inner_half_extents
+        rack_inner_polygon = (
+            obs._get_box_xy_polygon(  # pylint: disable=protected-access
+                obs.rack_pose, inner_half_extents
+            )
         )
-        part = obs.get_object_from_name(part_name)
-        if part.type == Kinematic3DCuboidType:
-            part_polygon = obs._get_box_xy_polygon(  # pylint: disable=protected-access
-                obs.get_object_pose(part_name),
-                obs.get_object_half_extents_packing3d(part_name)[:3],
-            )
-        else:
-            assert part.type == Kinematic3DTriangleType
-            part_polygon = obs._get_triangle_xy_polygon(  # pylint: disable=protected-access
-                part_name
-            )
+        part_vertices = self._get_part_convex_components(part_name)[0][0]
+        part_polygon = cast(Polygon, Polygon(part_vertices[:, :2]).convex_hull)
         if not rack_inner_polygon.buffer(1e-9).contains(part_polygon):
             return False
 
         part_id = self._object_name_to_pybullet_id(part_name)
-        part_lower, part_upper = p.getAABB(
-            part_id, 0, physicsClientId=self.physics_client_id
-        )
-        rack_floor_z = (
-            obs.rack_pose.position[2]
-            - rack_half_extents[2]
-            + wall_thickness
-        )
+        part_lower_z = float(part_vertices[:, 2].min())
+        part_upper_z = float(part_vertices[:, 2].max())
+        rack_floor_z = obs.rack_pose.position[2] - rack_half_extents[2] + wall_thickness
         rack_rim_z = obs.rack_pose.position[2] + rack_half_extents[2]
         tolerance = self.config.min_placement_dist
-        if not np.isclose(part_lower[2], rack_floor_z, atol=tolerance):
+        if not np.isclose(part_lower_z, rack_floor_z, atol=tolerance):
             return False
-        if part_upper[2] > rack_rim_z + tolerance:
+        if part_upper_z > rack_rim_z + tolerance:
             return False
 
         if self._bodies_penetrate(part_id, self._rack_id):

--- a/src/kinder/envs/kinematic3d/packing3d.py
+++ b/src/kinder/envs/kinematic3d/packing3d.py
@@ -48,6 +48,7 @@ class Packing3DEnvConfig(Kinematic3DEnvConfig, metaclass=FinalConfigMeta):
 
     # Robot.
     max_action_mag: float = 0.2
+    max_collision_check_step: float = 0.005
     robot_base_home_pose: SE2Pose = SE2Pose(-0.12, 0, 0)
     robot_base_z: float = -0.4
 
@@ -803,12 +804,32 @@ class ObjectCentricPacking3DEnv(
         if self._grasped_object is not None:
             return False
         obs = self._get_obs()
+        part_ids = []
         for i in range(self._num_parts):
             part_name = f"part{i}"
             if not self._part_is_seated_in_rack(part_name, obs):
                 return False
+            part_ids.append(self._object_name_to_pybullet_id(part_name))
+
+        # Containment and support are per-part properties, so check separately that
+        # the packed parts do not penetrate one another.
+        p.performCollisionDetection(physicsClientId=self.physics_client_id)
+        for i, part_id in enumerate(part_ids):
+            for other_part_id in part_ids[i + 1 :]:
+                if self._bodies_penetrate(part_id, other_part_id):
+                    return False
 
         return True
+
+    def _bodies_penetrate(self, body1: int, body2: int) -> bool:
+        """Check for penetration while allowing nonpenetrating support contact."""
+        contact_points = p.getClosestPoints(
+            body1,
+            body2,
+            distance=0.0,
+            physicsClientId=self.physics_client_id,
+        )
+        return any(point[8] < -1e-6 for point in contact_points)
 
     def _part_is_seated_in_rack(
         self, part_name: str, obs: Packing3DObjectCentricState
@@ -852,6 +873,9 @@ class ObjectCentricPacking3DEnv(
         if not np.isclose(part_lower[2], rack_floor_z, atol=tolerance):
             return False
         if part_upper[2] > rack_rim_z + tolerance:
+            return False
+
+        if self._bodies_penetrate(part_id, self._rack_id):
             return False
 
         return self._rack_id in self._get_surfaces_supporting_object(part_id)

--- a/src/kinder/envs/kinematic3d/packing3d.py
+++ b/src/kinder/envs/kinematic3d/packing3d.py
@@ -44,6 +44,7 @@ from kinder.envs.utils import PURPLE
 # Dimensions used by pybullet_helpers' part grasp pegs.
 _PART_PEG_HALF_EXTENTS = (0.01, 0.01, 0.025)
 _OVERLAP_TOLERANCE = 1e-6
+_MAX_PLACEMENT_ATTEMPTS = 100_000
 
 
 @dataclass(frozen=True)
@@ -175,8 +176,8 @@ class Packing3DObjectCentricState(Kinematic3DObjectCentricState):
     Adds convenience methods on top of Kinematic3DObjectCentricState().
     """
 
-    def get_object_pose(self, name: str) -> Pose:
-        """The pose of the object."""
+    def get_object_origin_pose(self, name: str) -> Pose:
+        """Get the pose stored in the state and used as the PyBullet body origin."""
         obj = self.get_object_from_name(name)
         position = (
             self.get(obj, "pose_x"),
@@ -190,20 +191,29 @@ class Packing3DObjectCentricState(Kinematic3DObjectCentricState):
             self.get(obj, "pose_qw"),
         )
 
-        if obj.type == Kinematic3DTriangleType:
-            # For triangle objects, we need to adjust the position to match the center
-            # of the triangular prism, since the pose is defined at the centroid of the
-            # triangle base.
-            side_a, side_b, _, triangle_type = self.get_object_triangle_features(name)
-            vertices = get_triangle_vertices(
-                {0: "equilateral", 1: "right"}[int(triangle_type)],
-                (side_a, side_b),
-            )
-            centroid_x = sum(v[0] for v in vertices) / 3.0 + self.get(obj, "pose_x")
-            centroid_y = sum(v[1] for v in vertices) / 3.0 + self.get(obj, "pose_y")
-            position = (centroid_x, centroid_y, self.get(obj, "pose_z"))
-
         return Pose(position, orientation)
+
+    def get_object_pose(self, name: str) -> Pose:
+        """Get the geometric center pose of an object."""
+        obj = self.get_object_from_name(name)
+        origin_pose = self.get_object_origin_pose(name)
+
+        if obj.type == Kinematic3DTriangleType:
+            side_a, side_b, _, triangle_type = self.get_object_triangle_features(name)
+            vertices = np.asarray(
+                get_triangle_vertices(
+                    {0: "equilateral", 1: "right"}[int(triangle_type)],
+                    (side_a, side_b),
+                )
+            )
+            local_centroid = np.mean(vertices, axis=0)
+            world_centroid_offset = Rotation.from_quat(origin_pose.orientation).apply(
+                local_centroid
+            )
+            position = tuple(np.asarray(origin_pose.position) + world_centroid_offset)
+            return Pose(position, origin_pose.orientation)
+
+        return origin_pose
 
     def get_object_half_extents_packing3d(
         self, name: str
@@ -403,7 +413,6 @@ class ObjectCentricPacking3DEnv(
         )
         set_pose(self.table_id, self.config.table_pose, self.physics_client_id)
 
-        # Rack (created in reset because geometry could be randomized later)
         self._rack_half_extents = self.config.rack_half_extents
         self._rack_id = create_pybullet_hollow_box(
             self.config.rack_rgba,
@@ -411,16 +420,11 @@ class ObjectCentricPacking3DEnv(
             wall_thickness=self.config.rack_wall_thickness,
             physics_client_id=self.physics_client_id,
         )
-        rack_pose = Pose(
-            (
-                self.config.table_pose.position[0],
-                self.config.table_pose.position[1],
-                self.config.table_pose.position[2]
-                + self.config.table_half_extents[2]
-                + self.config.rack_half_extents[2],
-            )
+        set_pose(
+            self._rack_id,
+            self._get_default_rack_pose(),
+            self.physics_client_id,
         )
-        set_pose(self._rack_id, rack_pose, self.physics_client_id)
 
         # Parts
         self._parts: dict[str, Object] = {}
@@ -430,6 +434,67 @@ class ObjectCentricPacking3DEnv(
         self._part_ids_to_triangle_features: dict[
             int, tuple[float, float, float, float]
         ] = {}
+
+    def _get_default_rack_pose(self) -> Pose:
+        return Pose(
+            (
+                self.config.table_pose.position[0],
+                self.config.table_pose.position[1],
+                self.config.table_pose.position[2]
+                + self.config.table_half_extents[2]
+                + self.config.rack_half_extents[2],
+            )
+        )
+
+    def _replace_rack(
+        self, half_extents: tuple[float, float, float], pose: Pose
+    ) -> None:
+        p.removeBody(self._rack_id, physicsClientId=self.physics_client_id)
+        self._rack_half_extents = half_extents
+        self._rack_id = create_pybullet_hollow_box(
+            self.config.rack_rgba,
+            half_extents=half_extents,
+            wall_thickness=self.config.rack_wall_thickness,
+            physics_client_id=self.physics_client_id,
+        )
+        set_pose(self._rack_id, pose, self.physics_client_id)
+
+    def _create_cuboid_part(
+        self, name: str, half_extents: tuple[float, float, float]
+    ) -> int:
+        part_id = create_pybullet_block_with_peg(
+            self.config.part_rgba,
+            half_extents=half_extents,
+            physics_client_id=self.physics_client_id,
+        )
+        self._part_ids[name] = part_id
+        self._part_ids_to_type[part_id] = Kinematic3DCuboidType
+        self._part_id_to_half_extents[part_id] = half_extents
+        return part_id
+
+    def _create_triangle_part(
+        self,
+        name: str,
+        triangle_features: tuple[float, float, float, float],
+    ) -> tuple[int, tuple[float, float, float]]:
+        side_a, side_b, depth, triangle_type = triangle_features
+        part_id = create_pybullet_triangle_with_peg(
+            self.config.part_rgba,
+            triangle_type={0: "equilateral", 1: "right"}[int(triangle_type)],
+            side_lengths=(side_a, side_b),
+            depth=depth,
+            physics_client_id=self.physics_client_id,
+        )
+        half_extents = (
+            max(side_a, side_b) / 2,
+            max(side_a, side_b) / 2,
+            depth / 2,
+        )
+        self._part_ids[name] = part_id
+        self._part_ids_to_type[part_id] = Kinematic3DTriangleType
+        self._part_id_to_half_extents[part_id] = half_extents
+        self._part_ids_to_triangle_features[part_id] = triangle_features
+        return part_id, half_extents
 
     @property
     def state_cls(self) -> TypingType[Kinematic3DObjectCentricState]:
@@ -558,6 +623,11 @@ class ObjectCentricPacking3DEnv(
 
     def _reset_objects(self) -> None:
 
+        self._replace_rack(
+            self.config.rack_half_extents,
+            self._get_default_rack_pose(),
+        )
+
         # Destroy previous parts.
         for old_id in set(self._part_ids.values()):
             if old_id is not None:
@@ -584,50 +654,20 @@ class ObjectCentricPacking3DEnv(
             if part_type == Kinematic3DCuboidType:
                 sampled = self.config.sample_part_half_extents(self.np_random)
                 half_extents = (sampled[0], sampled[1], sampled[2])
-                part_id = create_pybullet_block_with_peg(
-                    self.config.part_rgba,
-                    half_extents=half_extents,
-                    physics_client_id=self.physics_client_id,
-                )
-                self._part_id_to_half_extents[part_id] = half_extents
-                self._part_ids[name] = part_id
-                self._part_ids_to_type[part_id] = Kinematic3DCuboidType
-                self._part_ids_to_triangle_features[part_id] = (
-                    sampled[0],
-                    sampled[1],
-                    sampled[2],
-                    -1,
-                )
+                part_id = self._create_cuboid_part(name, half_extents)
 
-            elif part_type == Kinematic3DTriangleType:
-                side_a, side_b, depth, triangle_type = (
-                    self.config.sample_part_triangle_features(self.np_random)
+            else:
+                assert part_type == Kinematic3DTriangleType
+                triangle_features = self.config.sample_part_triangle_features(
+                    self.np_random
                 )
-                half_extents = (
-                    max(side_a, side_b) / 2,
-                    max(side_a, side_b) / 2,
-                    depth / 2,
-                )
-                part_id = create_pybullet_triangle_with_peg(
-                    self.config.part_rgba,
-                    triangle_type={0: "equilateral", 1: "right"}[int(triangle_type)],
-                    side_lengths=(side_a, side_b),
-                    depth=depth,
-                    physics_client_id=self.physics_client_id,
-                )
-                self._part_id_to_half_extents[part_id] = half_extents
-                self._part_ids[name] = part_id
-                self._part_ids_to_type[part_id] = Kinematic3DTriangleType
-                self._part_ids_to_triangle_features[part_id] = (
-                    side_a,
-                    side_b,
-                    depth,
-                    triangle_type,
+                part_id, half_extents = self._create_triangle_part(
+                    name, triangle_features
                 )
 
             # Place part on table while avoiding collisions with other parts and
             # the rack (we allow parts to start outside the rack)
-            for _ in range(100_000):
+            for _ in range(_MAX_PLACEMENT_ATTEMPTS):
                 # Sample a pose on the table surface.
                 x = self.np_random.uniform(
                     self.config.table_pose.position[0]
@@ -694,57 +734,47 @@ class ObjectCentricPacking3DEnv(
 
                 if not collision_exists:
                     break
+            else:
+                raise RuntimeError(
+                    f"Failed to place {name} without collision after "
+                    f"{_MAX_PLACEMENT_ATTEMPTS} attempts"
+                )
 
     def _set_object_states(self, obs: Kinematic3DObjectCentricState) -> None:
         assert isinstance(obs, Packing3DObjectCentricState)
-        # Update rack (recreate if half extents changed)
-        if self._rack_id is not None:
-            p.removeBody(self._rack_id, physicsClientId=self.physics_client_id)
-        self._rack_half_extents = self.config.rack_half_extents
-        self._rack_id = create_pybullet_hollow_box(
-            PURPLE + (0.8,),
-            half_extents=self._rack_half_extents,
-            wall_thickness=self.config.rack_wall_thickness,
-            physics_client_id=self.physics_client_id,
+
+        self._replace_rack(
+            obs.rack_half_extents,
+            obs.get_object_origin_pose("rack"),
         )
-        if self._rack_id is not None:
-            # Rack pose expected as a cuboid in the state
-            set_pose(self._rack_id, obs.get_object_pose("rack"), self.physics_client_id)
 
-        parts = obs.part_poses
-        assert (
-            len(parts) == self._num_parts
-        ), f"Expected {self._num_parts} parts, got {len(parts)}"
+        for old_id in set(self._part_ids.values()):
+            p.removeBody(old_id, physicsClientId=self.physics_client_id)
+        self._part_ids = {}
+        self._part_ids_to_type = {}
+        self._part_id_to_half_extents = {}
+        self._part_ids_to_triangle_features = {}
 
-        # Update parts
         for i in range(self._num_parts):
-            name = list(parts.keys())[i]
-            pose = self._get_pybullet_pose_from_state(obs, name)
-            part_id = self._object_name_to_pybullet_id(name)
-            set_pose(part_id, pose, self.physics_client_id)
+            name = f"part{i}"
+            part = obs.get_object_from_name(name)
+            if part.type == Kinematic3DCuboidType:
+                half_extents = obs.get_object_half_extents_packing3d(name)[:3]
+                part_id = self._create_cuboid_part(name, half_extents)
+            elif part.type == Kinematic3DTriangleType:
+                triangle_features = obs.get_object_triangle_features(name)
+                part_id, _ = self._create_triangle_part(name, triangle_features)
+            else:
+                raise ValueError(f"Unsupported part type: {part.type}")
 
-    def _get_pybullet_pose_from_state(
-        self, obs: Packing3DObjectCentricState, name: str
-    ) -> Pose:
-        """Get the raw PyBullet pose from state features for state restoration."""
-        obj = obs.get_object_from_name(name)
-        return Pose(
-            (
-                obs.get(obj, "pose_x"),
-                obs.get(obj, "pose_y"),
-                obs.get(obj, "pose_z"),
-            ),
-            (
-                obs.get(obj, "pose_qx"),
-                obs.get(obj, "pose_qy"),
-                obs.get(obj, "pose_qz"),
-                obs.get(obj, "pose_qw"),
-            ),
-        )
+            set_pose(
+                part_id,
+                obs.get_object_origin_pose(name),
+                self.physics_client_id,
+            )
 
     def _object_name_to_pybullet_id(self, object_name: str) -> int:
         if object_name == "rack":
-            assert self._rack_id is not None
             return self._rack_id
         if object_name == "table":
             return self.table_id
@@ -753,9 +783,7 @@ class ObjectCentricPacking3DEnv(
         raise ValueError(f"Unrecognized object name: {object_name}")
 
     def _get_collision_object_ids(self) -> set[int]:
-        ids = {self.table_id}
-        if self._rack_id is not None:
-            ids.add(self._rack_id)
+        ids = {self.table_id, self._rack_id}
         ids |= set(self._part_ids.values())
         return ids
 
@@ -764,10 +792,7 @@ class ObjectCentricPacking3DEnv(
 
     def _get_surface_object_names(self) -> set[str]:
         # The rack and table are surfaces.
-        names = {"table"}
-        if self._rack_id is not None:
-            names.add("rack")
-        return names
+        return {"table", "rack"}
 
     @staticmethod
     def _box_local_geometry(
@@ -861,9 +886,9 @@ class ObjectCentricPacking3DEnv(
         for vertices, face_normals, edge_directions in (main_geometry, peg_geometry):
             world_components.append(
                 (
-                    (rotation @ vertices.T).T + translation,
-                    (rotation @ face_normals.T).T,
-                    (rotation @ edge_directions.T).T,
+                    np.transpose(rotation @ np.transpose(vertices)) + translation,
+                    np.transpose(rotation @ np.transpose(face_normals)),
+                    np.transpose(rotation @ np.transpose(edge_directions)),
                 )
             )
         return world_components
@@ -920,7 +945,7 @@ class ObjectCentricPacking3DEnv(
 
     def _get_half_extents(self, object_name: str) -> tuple[float, float, float]:
         if object_name == "rack":
-            return self.config.rack_half_extents
+            return self._rack_half_extents
         if object_name == "table":
             return self.config.table_half_extents
         assert object_name.startswith("part")

--- a/tests/envs/kinematic3d/test_packing3d.py
+++ b/tests/envs/kinematic3d/test_packing3d.py
@@ -54,8 +54,8 @@ def test_packing3d_env_basic():
         env.close()
 
 
-def test_packing3d_action_magnitude_matches_other_manipulation_envs() -> None:
-    """Packing3D uses the standard fine-grained manipulation action bound."""
+def test_packing3d_uses_standard_action_magnitude() -> None:
+    """Packing3D uses the standard action bound used by the 3D envs."""
     env = Packing3DEnv(num_parts=1, use_gui=False, realistic_bg=False)
     assert np.all(env.action_space.low[:10] == -0.2)
     assert np.all(env.action_space.high[:10] == 0.2)

--- a/tests/envs/kinematic3d/test_packing3d.py
+++ b/tests/envs/kinematic3d/test_packing3d.py
@@ -49,6 +49,14 @@ def test_packing3d_env_basic():
         env.close()
 
 
+def test_packing3d_action_magnitude_matches_other_manipulation_envs() -> None:
+    """Packing3D uses the standard fine-grained manipulation action bound."""
+    env = Packing3DEnv(num_parts=1, use_gui=False, realistic_bg=False)
+    assert np.all(env.action_space.low[:10] == -0.2)
+    assert np.all(env.action_space.high[:10] == 0.2)
+    env.close()
+
+
 def test_packing3d_rejects_collision_tunneling_action() -> None:
     """A collision-free endpoint is invalid when the swept motion collides."""
     env = Packing3DEnv(
@@ -86,8 +94,8 @@ def test_packing3d_rejects_collision_tunneling_action() -> None:
     env.close()
 
 
-def test_packing3d_goal():
-    """Test the current triangle containment issue in Packing3D goal checks."""
+def test_packing3d_goal_rejects_part_outside_rack_cavity():
+    """A part on the outer rack footprint is not seated in its cavity."""
     env = ObjectCentricPacking3DEnv(
         num_parts=1,
         use_gui=False,
@@ -156,7 +164,7 @@ def test_packing3d_goal():
         updated_obs.get_object_half_extents_packing3d("part0")[:3],
     )
     assert "part0" not in updated_obs.available_parts
-    assert env.goal_reached()
+    assert not env.goal_reached()
 
     env.close()
 

--- a/tests/envs/kinematic3d/test_packing3d.py
+++ b/tests/envs/kinematic3d/test_packing3d.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 import numpy as np
 import pybullet as p
 import pytest
+from gymnasium.spaces import Box
 from gymnasium.wrappers import RecordVideo
 from prpl_utils.utils import wrap_angle
 from pybullet_helpers.geometry import Pose, get_pose, multiply_poses, set_pose
@@ -60,9 +61,10 @@ def test_packing3d_env_basic():
 def test_packing3d_uses_standard_action_magnitude() -> None:
     """Packing3D uses a 0.2 action bound."""
     env = Packing3DEnv(num_parts=1, use_gui=False, realistic_bg=False)
+    assert isinstance(env.action_space, Box)
     assert np.all(env.action_space.low[:10] == -0.2)
     assert np.all(env.action_space.high[:10] == 0.2)
-    assert env.unwrapped._object_centric_env.config.max_collision_check_step == 0.005
+    assert env._object_centric_env.config.max_collision_check_step == 0.005
     env.close()
 
 

--- a/tests/envs/kinematic3d/test_packing3d.py
+++ b/tests/envs/kinematic3d/test_packing3d.py
@@ -3,9 +3,10 @@
 from typing import Any, cast
 
 import numpy as np
+import pybullet as p
 from gymnasium.wrappers import RecordVideo
 from prpl_utils.utils import wrap_angle
-from pybullet_helpers.geometry import Pose, multiply_poses
+from pybullet_helpers.geometry import Pose, get_pose, multiply_poses, set_pose
 from pybullet_helpers.motion_planning import (
     create_joint_distance_fn,
     remap_joint_position_plan_to_constant_distance,
@@ -54,6 +55,7 @@ def test_packing3d_action_magnitude_matches_other_manipulation_envs() -> None:
     env = Packing3DEnv(num_parts=1, use_gui=False, realistic_bg=False)
     assert np.all(env.action_space.low[:10] == -0.2)
     assert np.all(env.action_space.high[:10] == 0.2)
+    assert env.unwrapped._object_centric_env.config.max_collision_check_step == 0.005
     env.close()
 
 
@@ -166,6 +168,89 @@ def test_packing3d_goal_rejects_part_outside_rack_cavity():
     assert "part0" not in updated_obs.available_parts
     assert not env.goal_reached()
 
+    env.close()
+
+
+def test_packing3d_goal_rejects_overlapping_parts() -> None:
+    """Individually seated parts must not penetrate one another."""
+    env = ObjectCentricPacking3DEnv(
+        num_parts=2,
+        use_gui=False,
+        realistic_bg=False,
+        allow_state_access=True,
+    )
+    env.reset(seed=0)
+    rack_pose = get_pose(env._rack_id, env.physics_client_id)
+    floor_z = (
+        rack_pose.position[2]
+        - env.config.rack_half_extents[2]
+        + env.config.rack_wall_thickness
+    )
+
+    # Put both parts at the same supported pose in the middle of the cavity. Account
+    # for the different base-to-geometry offsets of cuboids and triangles.
+    for part_name in ("part0", "part1"):
+        part_id = env._part_ids[part_name]
+        part_pose = get_pose(part_id, env.physics_client_id)
+        part_lower, _ = p.getAABB(
+            part_id, 0, physicsClientId=env.physics_client_id
+        )
+        lower_z_offset = part_lower[2] - part_pose.position[2]
+        set_pose(
+            part_id,
+            Pose(
+                (
+                    rack_pose.position[0] - 0.03,
+                    rack_pose.position[1] - 0.02,
+                    floor_z + 0.002 - lower_z_offset,
+                )
+            ),
+            env.physics_client_id,
+        )
+
+    obs = env.get_state()
+    assert env._part_is_seated_in_rack("part0", obs)
+    assert env._part_is_seated_in_rack("part1", obs)
+    assert not env.goal_reached()
+    env.close()
+
+
+def test_packing3d_goal_rejects_rack_penetration_and_hovering() -> None:
+    """Cavity containment alone is insufficient without valid floor support."""
+    env = ObjectCentricPacking3DEnv(
+        num_parts=1,
+        use_gui=False,
+        realistic_bg=False,
+        allow_state_access=True,
+    )
+    env.reset(seed=0)
+    rack_pose = get_pose(env._rack_id, env.physics_client_id)
+    floor_z = (
+        rack_pose.position[2]
+        - env.config.rack_half_extents[2]
+        + env.config.rack_wall_thickness
+    )
+    part_id = env._part_ids["part0"]
+    part_pose = get_pose(part_id, env.physics_client_id)
+    part_lower, _ = p.getAABB(part_id, 0, physicsClientId=env.physics_client_id)
+    lower_z_offset = part_lower[2] - part_pose.position[2]
+    xy = (rack_pose.position[0] - 0.03, rack_pose.position[1] - 0.02)
+
+    # The footprint is inside and the part is near the floor, but it penetrates it.
+    set_pose(
+        part_id,
+        Pose((*xy, floor_z - 0.002 - lower_z_offset)),
+        env.physics_client_id,
+    )
+    assert not env.goal_reached()
+
+    # The footprint remains inside, but the part is too high to be supported.
+    set_pose(
+        part_id,
+        Pose((*xy, floor_z + 0.01 - lower_z_offset)),
+        env.physics_client_id,
+    )
+    assert not env.goal_reached()
     env.close()
 
 

--- a/tests/envs/kinematic3d/test_packing3d.py
+++ b/tests/envs/kinematic3d/test_packing3d.py
@@ -1,5 +1,7 @@
 """Tests for packing3d.py."""
 
+# pylint: disable=protected-access
+
 from typing import Any, cast
 
 import numpy as np
@@ -17,6 +19,7 @@ from pybullet_helpers.motion_planning import (
 from pybullet_helpers.utils import get_triangle_vertices
 from relational_structs import Object
 from relational_structs.spaces import ObjectCentricBoxSpace
+from scipy.spatial.transform import Rotation
 from shapely.geometry import Polygon
 
 from kinder.envs.kinematic3d.object_types import (
@@ -60,6 +63,147 @@ def test_packing3d_uses_standard_action_magnitude() -> None:
     assert np.all(env.action_space.low[:10] == -0.2)
     assert np.all(env.action_space.high[:10] == 0.2)
     assert env.unwrapped._object_centric_env.config.max_collision_check_step == 0.005
+    env.close()
+
+
+def test_packing3d_rotated_triangle_state_round_trip() -> None:
+    """Triangle state poses round-trip without moving the PyBullet body origin."""
+    env = ObjectCentricPacking3DEnv(
+        num_parts=1,
+        config=Packing3DEnvConfig(part_triangular_prob=0.0),
+        use_gui=False,
+        realistic_bg=False,
+        allow_state_access=True,
+    )
+    obs, _ = env.reset(seed=0)
+    part = obs.get_object_from_name("part0")
+    assert part.type == Kinematic3DTriangleType
+
+    origin_position = (0.18, -0.11, 0.09)
+    orientation = tuple(Rotation.from_euler("z", np.pi / 2).as_quat())
+    for feature, value in zip(
+        ("pose_x", "pose_y", "pose_z"), origin_position, strict=True
+    ):
+        obs.set(part, feature, value)
+    for feature, value in zip(
+        ("pose_qx", "pose_qy", "pose_qz", "pose_qw"),
+        orientation,
+        strict=True,
+    ):
+        obs.set(part, feature, value)
+    obs.set(part, "side_a", 0.12)
+    obs.set(part, "side_b", 0.09)
+    obs.set(part, "depth", 0.02)
+    obs.set(part, "triangle_type", 1.0)
+
+    local_vertices = np.asarray(get_triangle_vertices("right", (0.12, 0.09)))
+    expected_center = np.asarray(origin_position) + Rotation.from_quat(
+        orientation
+    ).apply(np.mean(local_vertices, axis=0))
+    assert np.allclose(obs.get_object_pose("part0").position, expected_center)
+
+    env.set_state(obs)
+    restored = env.get_state()
+    assert obs.allclose(restored)
+    assert restored.get_object_origin_pose("part0").allclose(
+        Pose(origin_position, orientation)
+    )
+    assert restored.get_object_pose("part0").allclose(
+        Pose(tuple(expected_center), orientation)
+    )
+    assert get_pose(
+        env._part_ids["part0"],
+        env.physics_client_id,  # pylint: disable=protected-access
+    ).allclose(Pose(origin_position, orientation))
+    env.close()
+
+
+def test_packing3d_set_state_recreates_geometry() -> None:
+    """Part and rack dimensions in a state determine the recreated bodies."""
+    config = Packing3DEnvConfig(part_triangular_prob=0.5)
+    env = ObjectCentricPacking3DEnv(
+        num_parts=2,
+        config=config,
+        use_gui=False,
+        realistic_bg=False,
+        allow_state_access=True,
+    )
+    obs, _ = env.reset(seed=0)
+    cuboid = obs.get_object_from_name("part0")
+    triangle = obs.get_object_from_name("part1")
+    rack = obs.get_object_from_name("rack")
+    assert cuboid.type == Kinematic3DCuboidType
+    assert triangle.type == Kinematic3DTriangleType
+
+    cuboid_half_extents = (0.035, 0.04, 0.012)
+    for feature, value in zip(
+        ("half_extent_x", "half_extent_y", "half_extent_z"),
+        cuboid_half_extents,
+        strict=True,
+    ):
+        obs.set(cuboid, feature, value)
+    triangle_features = (0.07, 0.09, 0.018, 1.0)
+    for feature, value in zip(
+        ("side_a", "side_b", "depth", "triangle_type"),
+        triangle_features,
+        strict=True,
+    ):
+        obs.set(triangle, feature, value)
+    rack_half_extents = (0.13, 0.18, 0.025)
+    for feature, value in zip(
+        ("half_extent_x", "half_extent_y", "half_extent_z"),
+        rack_half_extents,
+        strict=True,
+    ):
+        obs.set(rack, feature, value)
+
+    env.set_state(obs)
+    restored = env.get_state()
+    assert obs.allclose(restored)
+    assert np.allclose(
+        restored.get_object_half_extents_packing3d("part0")[:3],
+        cuboid_half_extents,
+    )
+    assert np.allclose(
+        restored.get_object_triangle_features("part1"), triangle_features
+    )
+    assert np.allclose(restored.rack_half_extents, rack_half_extents)
+
+    cuboid_id = env._part_ids["part0"]  # pylint: disable=protected-access
+    triangle_id = env._part_ids["part1"]  # pylint: disable=protected-access
+    assert env._part_ids_to_type[cuboid_id] == Kinematic3DCuboidType
+    assert env._part_ids_to_type[triangle_id] == Kinematic3DTriangleType
+    assert cuboid_id not in env._part_ids_to_triangle_features
+    assert np.allclose(
+        env._part_ids_to_triangle_features[triangle_id], triangle_features
+    )
+    aabb_min, aabb_max = p.getAABB(
+        cuboid_id, linkIndex=0, physicsClientId=env.physics_client_id
+    )
+    assert np.allclose(
+        np.asarray(aabb_max) - np.asarray(aabb_min),
+        2 * np.asarray(cuboid_half_extents),
+    )
+
+    reset_obs, _ = env.reset(seed=1)
+    assert np.allclose(reset_obs.rack_half_extents, config.rack_half_extents)
+    env.close()
+
+
+def test_packing3d_reset_raises_when_placement_is_infeasible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reset fails explicitly when rejection sampling exhausts its attempts."""
+    monkeypatch.setattr("kinder.envs.kinematic3d.packing3d._MAX_PLACEMENT_ATTEMPTS", 2)
+    env = ObjectCentricPacking3DEnv(
+        num_parts=1,
+        config=Packing3DEnvConfig(rack_half_extents=(1.0, 1.0, 0.02)),
+        use_gui=False,
+        realistic_bg=False,
+        allow_state_access=True,
+    )
+    with pytest.raises(RuntimeError, match="Failed to place part0"):
+        env.reset(seed=0)
     env.close()
 
 
@@ -123,9 +267,6 @@ def test_packing3d_goal_rejects_part_outside_rack_cavity():
     part_x = rack_pose.position[0] - rack_half_extents[0]
     part_y = rack_pose.position[1] - side_b / 2
 
-    # set_state() restores triangle pose fields as raw PyBullet body poses.
-    # Subtracting the centroid here would encode the old get_object_pose()
-    # restoration behavior and place the true triangle footprint outside the rack.
     obs.set(part, "pose_x", part_x)
     obs.set(part, "pose_y", part_y)
     obs.set(part, "pose_z", rack_pose.position[2])

--- a/tests/envs/kinematic3d/test_packing3d.py
+++ b/tests/envs/kinematic3d/test_packing3d.py
@@ -262,7 +262,7 @@ def test_packing3d_goal_handles_every_part_shape_pair(
     obs = env.get_state()
     assert env._part_is_seated_in_rack("part0", obs)
     assert env._part_is_seated_in_rack("part1", obs)
-    assert env._parts_penetrate("part0", "part1")
+    assert env._parts_overlap("part0", "part1")
     assert not env.goal_reached()
 
     _place_part_on_rack_floor(
@@ -274,13 +274,13 @@ def test_packing3d_goal_handles_every_part_shape_pair(
     obs = env.get_state()
     assert env._part_is_seated_in_rack("part0", obs)
     assert env._part_is_seated_in_rack("part1", obs)
-    assert not env._parts_penetrate("part0", "part1")
+    assert not env._parts_overlap("part0", "part1")
     assert env.goal_reached()
     env.close()
 
 
 def test_packing3d_rejects_triangle_overlap_missed_by_pybullet() -> None:
-    """Analytic geometry catches triangular-prism penetration."""
+    """Analytic geometry catches triangular-prism overlap."""
     env = ObjectCentricPacking3DEnv(
         num_parts=2,
         config=Packing3DEnvConfig(part_triangular_prob=0.0),
@@ -303,8 +303,8 @@ def test_packing3d_rejects_triangle_overlap_missed_by_pybullet() -> None:
 
     part0_id = env._part_ids["part0"]
     part1_id = env._part_ids["part1"]
-    assert not env._bodies_penetrate(part0_id, part1_id)
-    assert env._parts_penetrate("part0", "part1")
+    assert not env._bodies_overlap(part0_id, part1_id)
+    assert env._parts_overlap("part0", "part1")
     assert not env.goal_reached()
 
     # Held parts use the same analytic collision check.
@@ -331,16 +331,16 @@ def test_packing3d_part_collision_includes_grasp_pegs() -> None:
     second_id = env._part_ids["part1"]
     set_pose(first_id, Pose((0.0, 0.0, 0.0)), env.physics_client_id)
 
-    # The main bodies are separate while the lower peg penetrates the upper body.
+    # The main bodies are separate while the lower peg overlaps the upper body.
     set_pose(second_id, Pose((0.0, 0.0, 0.065)), env.physics_client_id)
     first_main = env._get_part_convex_components("part0")[0][0]
     second_main = env._get_part_convex_components("part1")[0][0]
     assert first_main[:, 2].max() < second_main[:, 2].min()
-    assert env._parts_penetrate("part0", "part1")
+    assert env._parts_overlap("part0", "part1")
 
-    # Exact contact is allowed; only strict penetration is rejected.
+    # Exact contact is allowed; only strict overlap is rejected.
     set_pose(second_id, Pose((0.0, 0.0, 0.07)), env.physics_client_id)
-    assert not env._parts_penetrate("part0", "part1")
+    assert not env._parts_overlap("part0", "part1")
     env.close()
 
 
@@ -360,13 +360,13 @@ def test_packing3d_reset_avoids_analytic_part_overlap(
         env.reset(seed=seed)
         for first_index in range(3):
             for second_index in range(first_index + 1, 3):
-                assert not env._parts_penetrate(
+                assert not env._parts_overlap(
                     f"part{first_index}", f"part{second_index}"
                 )
     env.close()
 
 
-def test_packing3d_goal_rejects_rack_penetration_and_hovering() -> None:
+def test_packing3d_goal_rejects_rack_overlap_and_hovering() -> None:
     """Cavity containment alone is insufficient without valid floor support."""
     env = ObjectCentricPacking3DEnv(
         num_parts=1,
@@ -387,7 +387,7 @@ def test_packing3d_goal_rejects_rack_penetration_and_hovering() -> None:
     lower_z_offset = part_lower[2] - part_pose.position[2]
     xy = (rack_pose.position[0] - 0.03, rack_pose.position[1] - 0.02)
 
-    # The footprint is inside and the part is near the floor, but it penetrates it.
+    # The footprint is inside and the part overlaps the rack floor.
     set_pose(
         part_id,
         Pose((*xy, floor_z - 0.002 - lower_z_offset)),

--- a/tests/envs/kinematic3d/test_packing3d.py
+++ b/tests/envs/kinematic3d/test_packing3d.py
@@ -55,7 +55,7 @@ def test_packing3d_env_basic():
 
 
 def test_packing3d_uses_standard_action_magnitude() -> None:
-    """Packing3D uses the standard action bound used by the 3D envs."""
+    """Packing3D uses a 0.2 action bound."""
     env = Packing3DEnv(num_parts=1, use_gui=False, realistic_bg=False)
     assert np.all(env.action_space.low[:10] == -0.2)
     assert np.all(env.action_space.high[:10] == 0.2)
@@ -252,8 +252,7 @@ def test_packing3d_goal_handles_every_part_shape_pair(
     )
     rack_pose = get_pose(env._rack_id, env.physics_client_id)
 
-    # Rotate one part to exercise non-axis-aligned cuboid and triangle geometry.
-    # Both parts occupy the same supported rack region and must be rejected.
+    # Overlap two rotated parts inside the rack.
     target_xy = (rack_pose.position[0], rack_pose.position[1])
     for part_name in ("part0", "part1"):
         _place_part_on_rack_floor(
@@ -266,7 +265,6 @@ def test_packing3d_goal_handles_every_part_shape_pair(
     assert env._parts_penetrate("part0", "part1")
     assert not env.goal_reached()
 
-    # The same shapes are a valid terminal arrangement when separated.
     _place_part_on_rack_floor(
         env, "part0", (rack_pose.position[0], rack_pose.position[1] - 0.07)
     )
@@ -282,7 +280,7 @@ def test_packing3d_goal_handles_every_part_shape_pair(
 
 
 def test_packing3d_rejects_triangle_overlap_missed_by_pybullet() -> None:
-    """Analytic geometry catches the mesh-query false negative from the replay."""
+    """Analytic geometry catches triangular-prism penetration."""
     env = ObjectCentricPacking3DEnv(
         num_parts=2,
         config=Packing3DEnvConfig(part_triangular_prob=0.0),
@@ -309,8 +307,7 @@ def test_packing3d_rejects_triangle_overlap_missed_by_pybullet() -> None:
     assert env._parts_penetrate("part0", "part1")
     assert not env.goal_reached()
 
-    # The same analytic check participates in swept validation while carrying a
-    # triangle; the PyBullet-only result above must not allow this configuration.
+    # Held parts use the same analytic collision check.
     env._grasped_object = "part0"
     env._grasped_object_transform = multiply_poses(
         env.robot.arm.get_end_effector_pose().invert(),
@@ -321,7 +318,7 @@ def test_packing3d_rejects_triangle_overlap_missed_by_pybullet() -> None:
 
 
 def test_packing3d_part_collision_includes_grasp_pegs() -> None:
-    """The analytic part geometry includes the red peg, not just the main body."""
+    """Part collision geometry includes grasp pegs."""
     env = ObjectCentricPacking3DEnv(
         num_parts=2,
         config=Packing3DEnvConfig(part_triangular_prob=1.0),
@@ -334,8 +331,7 @@ def test_packing3d_part_collision_includes_grasp_pegs() -> None:
     second_id = env._part_ids["part1"]
     set_pose(first_id, Pose((0.0, 0.0, 0.0)), env.physics_client_id)
 
-    # The 2-cm-tall main cuboids are vertically separate, but the lower part's
-    # 5-cm grasp peg penetrates the upper part's main body by 5 mm.
+    # The main bodies are separate while the lower peg penetrates the upper body.
     set_pose(second_id, Pose((0.0, 0.0, 0.065)), env.physics_client_id)
     first_main = env._get_part_convex_components("part0")[0][0]
     second_main = env._get_part_convex_components("part1")[0][0]

--- a/tests/envs/kinematic3d/test_packing3d.py
+++ b/tests/envs/kinematic3d/test_packing3d.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 
 import numpy as np
 import pybullet as p
+import pytest
 from gymnasium.wrappers import RecordVideo
 from prpl_utils.utils import wrap_angle
 from pybullet_helpers.geometry import Pose, get_pose, multiply_poses, set_pose
@@ -18,7 +19,10 @@ from relational_structs import Object
 from relational_structs.spaces import ObjectCentricBoxSpace
 from shapely.geometry import Polygon
 
-from kinder.envs.kinematic3d.object_types import Kinematic3DTriangleType
+from kinder.envs.kinematic3d.object_types import (
+    Kinematic3DCuboidType,
+    Kinematic3DTriangleType,
+)
 from kinder.envs.kinematic3d.packing3d import (
     ObjectCentricPacking3DEnv,
     Packing3DEnv,
@@ -171,47 +175,198 @@ def test_packing3d_goal_rejects_part_outside_rack_cavity():
     env.close()
 
 
-def test_packing3d_goal_rejects_overlapping_parts() -> None:
-    """Individually seated parts must not penetrate one another."""
-    env = ObjectCentricPacking3DEnv(
-        num_parts=2,
-        use_gui=False,
-        realistic_bg=False,
-        allow_state_access=True,
+def _get_part_shape_name(obs: Packing3DObjectCentricState, part_name: str) -> str:
+    part = obs.get_object_from_name(part_name)
+    if part.type == Kinematic3DCuboidType:
+        return "cuboid"
+    assert part.type == Kinematic3DTriangleType
+    triangle_type = obs.get_object_triangle_features(part_name)[3]
+    return {0: "equilateral", 1: "right"}[int(triangle_type)]
+
+
+def _place_part_on_rack_floor(
+    env: ObjectCentricPacking3DEnv,
+    part_name: str,
+    target_xy: tuple[float, float],
+    yaw: float = 0.0,
+) -> None:
+    part_id = env._part_ids[part_name]
+    old_pose = get_pose(part_id, env.physics_client_id)
+    orientation = Pose.from_rpy((0.0, 0.0, 0.0), (0.0, 0.0, yaw)).orientation
+    set_pose(
+        part_id,
+        Pose(old_pose.position, orientation),
+        env.physics_client_id,
     )
-    env.reset(seed=0)
+    vertices = env._get_part_convex_components(part_name)[0][0]
+    polygon = Polygon(vertices[:, :2]).convex_hull
     rack_pose = get_pose(env._rack_id, env.physics_client_id)
     floor_z = (
         rack_pose.position[2]
         - env.config.rack_half_extents[2]
         + env.config.rack_wall_thickness
     )
-
-    # Put both parts at the same supported pose in the middle of the cavity. Account
-    # for the different base-to-geometry offsets of cuboids and triangles.
-    for part_name in ("part0", "part1"):
-        part_id = env._part_ids[part_name]
-        part_pose = get_pose(part_id, env.physics_client_id)
-        part_lower, _ = p.getAABB(
-            part_id, 0, physicsClientId=env.physics_client_id
-        )
-        lower_z_offset = part_lower[2] - part_pose.position[2]
-        set_pose(
-            part_id,
-            Pose(
-                (
-                    rack_pose.position[0] - 0.03,
-                    rack_pose.position[1] - 0.02,
-                    floor_z + 0.002 - lower_z_offset,
-                )
+    current_pose = get_pose(part_id, env.physics_client_id)
+    set_pose(
+        part_id,
+        Pose(
+            (
+                current_pose.position[0] + target_xy[0] - polygon.centroid.x,
+                current_pose.position[1] + target_xy[1] - polygon.centroid.y,
+                current_pose.position[2] + floor_z + 0.002 - vertices[:, 2].min(),
             ),
-            env.physics_client_id,
+            current_pose.orientation,
+        ),
+        env.physics_client_id,
+    )
+
+
+@pytest.mark.parametrize(
+    ("triangle_probability", "seed", "expected_shapes"),
+    [
+        (1.0, 0, ("cuboid", "cuboid")),
+        (0.5, 0, ("cuboid", "right")),
+        (0.5, 5, ("cuboid", "equilateral")),
+        (0.0, 0, ("right", "right")),
+        (0.0, 1, ("equilateral", "right")),
+        (0.0, 11, ("equilateral", "equilateral")),
+    ],
+)
+def test_packing3d_goal_handles_every_part_shape_pair(
+    triangle_probability: float,
+    seed: int,
+    expected_shapes: tuple[str, str],
+) -> None:
+    """All supported shape pairs reject overlap and accept clear packing."""
+    env = ObjectCentricPacking3DEnv(
+        num_parts=2,
+        config=Packing3DEnvConfig(part_triangular_prob=triangle_probability),
+        use_gui=False,
+        realistic_bg=False,
+        allow_state_access=True,
+    )
+    obs, _ = env.reset(seed=seed)
+    assert (
+        tuple(_get_part_shape_name(obs, f"part{i}") for i in range(2))
+        == expected_shapes
+    )
+    rack_pose = get_pose(env._rack_id, env.physics_client_id)
+
+    # Rotate one part to exercise non-axis-aligned cuboid and triangle geometry.
+    # Both parts occupy the same supported rack region and must be rejected.
+    target_xy = (rack_pose.position[0], rack_pose.position[1])
+    for part_name in ("part0", "part1"):
+        _place_part_on_rack_floor(
+            env, part_name, target_xy, yaw=0.0 if part_name == "part0" else np.pi / 6
         )
 
     obs = env.get_state()
     assert env._part_is_seated_in_rack("part0", obs)
     assert env._part_is_seated_in_rack("part1", obs)
+    assert env._parts_penetrate("part0", "part1")
     assert not env.goal_reached()
+
+    # The same shapes are a valid terminal arrangement when separated.
+    _place_part_on_rack_floor(
+        env, "part0", (rack_pose.position[0], rack_pose.position[1] - 0.07)
+    )
+    _place_part_on_rack_floor(
+        env, "part1", (rack_pose.position[0], rack_pose.position[1] + 0.07)
+    )
+    obs = env.get_state()
+    assert env._part_is_seated_in_rack("part0", obs)
+    assert env._part_is_seated_in_rack("part1", obs)
+    assert not env._parts_penetrate("part0", "part1")
+    assert env.goal_reached()
+    env.close()
+
+
+def test_packing3d_rejects_triangle_overlap_missed_by_pybullet() -> None:
+    """Analytic geometry catches the mesh-query false negative from the replay."""
+    env = ObjectCentricPacking3DEnv(
+        num_parts=2,
+        config=Packing3DEnvConfig(part_triangular_prob=0.0),
+        use_gui=False,
+        realistic_bg=False,
+        allow_state_access=True,
+    )
+    obs, _ = env.reset(seed=0)
+    assert tuple(_get_part_shape_name(obs, f"part{i}") for i in range(2)) == (
+        "right",
+        "right",
+    )
+    rack_pose = get_pose(env._rack_id, env.physics_client_id)
+    _place_part_on_rack_floor(
+        env, "part0", (rack_pose.position[0] - 0.003, rack_pose.position[1] - 0.028)
+    )
+    _place_part_on_rack_floor(
+        env, "part1", (rack_pose.position[0] + 0.003, rack_pose.position[1] + 0.028)
+    )
+
+    part0_id = env._part_ids["part0"]
+    part1_id = env._part_ids["part1"]
+    assert not env._bodies_penetrate(part0_id, part1_id)
+    assert env._parts_penetrate("part0", "part1")
+    assert not env.goal_reached()
+
+    # The same analytic check participates in swept validation while carrying a
+    # triangle; the PyBullet-only result above must not allow this configuration.
+    env._grasped_object = "part0"
+    env._grasped_object_transform = multiply_poses(
+        env.robot.arm.get_end_effector_pose().invert(),
+        get_pose(part0_id, env.physics_client_id),
+    )
+    assert env._robot_or_held_object_collision_exists()
+    env.close()
+
+
+def test_packing3d_part_collision_includes_grasp_pegs() -> None:
+    """The analytic part geometry includes the red peg, not just the main body."""
+    env = ObjectCentricPacking3DEnv(
+        num_parts=2,
+        config=Packing3DEnvConfig(part_triangular_prob=1.0),
+        use_gui=False,
+        realistic_bg=False,
+        allow_state_access=True,
+    )
+    env.reset(seed=0)
+    first_id = env._part_ids["part0"]
+    second_id = env._part_ids["part1"]
+    set_pose(first_id, Pose((0.0, 0.0, 0.0)), env.physics_client_id)
+
+    # The 2-cm-tall main cuboids are vertically separate, but the lower part's
+    # 5-cm grasp peg penetrates the upper part's main body by 5 mm.
+    set_pose(second_id, Pose((0.0, 0.0, 0.065)), env.physics_client_id)
+    first_main = env._get_part_convex_components("part0")[0][0]
+    second_main = env._get_part_convex_components("part1")[0][0]
+    assert first_main[:, 2].max() < second_main[:, 2].min()
+    assert env._parts_penetrate("part0", "part1")
+
+    # Exact contact is allowed; only strict penetration is rejected.
+    set_pose(second_id, Pose((0.0, 0.0, 0.07)), env.physics_client_id)
+    assert not env._parts_penetrate("part0", "part1")
+    env.close()
+
+
+@pytest.mark.parametrize("triangle_probability", [0.0, 0.5, 1.0])
+def test_packing3d_reset_avoids_analytic_part_overlap(
+    triangle_probability: float,
+) -> None:
+    """Initial rejection sampling works for triangle and cuboid mixtures."""
+    env = ObjectCentricPacking3DEnv(
+        num_parts=3,
+        config=Packing3DEnvConfig(part_triangular_prob=triangle_probability),
+        use_gui=False,
+        realistic_bg=False,
+        allow_state_access=True,
+    )
+    for seed in range(10):
+        env.reset(seed=seed)
+        for first_index in range(3):
+            for second_index in range(first_index + 1, 3):
+                assert not env._parts_penetrate(
+                    f"part{first_index}", f"part{second_index}"
+                )
     env.close()
 
 


### PR DESCRIPTION
## Summary

This PR makes Packing3D enforce its motion, state, and terminal-geometry contracts:

- use a `0.2` maximum action delta and opt into swept collision validation at 5 mm spacing;
- require every part to be fully seated inside the rack cavity, supported at the rack floor, and below the rim;
- reject strict overlap between seated parts;
- use analytic convex geometry for cuboids, right-triangular prisms, equilateral-triangular prisms, and their grasp pegs during reset sampling, carried-object collision checking, and terminal validation;
- reconstruct part types, dimensions, poses, and rack extents from the supplied state in `set_state()`; and
- raise `RuntimeError` if reset rejection sampling cannot find a valid part placement.

The reward remains sparse. This PR changes which transitions and terminal arrangements are valid, not how intermediate progress is scored.

## Motivation

The original three-part controller solved 100/100 evaluation episodes in 6.67 actions on average. On the example seed below it used exactly six actions: one jump-and-close and one jump-and-open per part. The endpoints were accepted, but dense replay found collisions along the interpolated robot and held-object paths. A `0.2` bound made the motion less abrupt but did not eliminate these invalid paths, so the environment also needs swept validation.

The terminal predicate had a separate geometry gap. It checked projected containment in the rack footprint, but did not establish that each part was resting at the rack floor, below the rim, and non-overlapping with every other part. PyBullet's fixed-link triangle mesh queries can also report a positive gap for visibly overlapping triangular parts, so the environment cannot rely on those queries alone for these shapes.

State restoration also needs to reproduce the geometry described by the supplied state. Randomized part and rack dimensions should not depend on the most recent reset, and triangle geometric centers must rotate their local centroid offset with the stored orientation.

## Relationship to #88

#88 fixed triangle drift by restoring the raw PyBullet body-origin pose and added a repeated no-drift regression. This PR keeps that behavior and test. Because full geometry reconstruction needs the same raw pose for parts and the rack, the raw-origin accessor now lives on `Packing3DObjectCentricState`; the redundant environment helper from #88 is removed. This layer adds orientation-aware geometric centers and reconstruction of state-defined types, dimensions, poses, body IDs, feature mappings, and rack extents.

## Behavior

| Before | After |
| --- | --- |
| ![Packing3D six-action endpoint-only solution](https://raw.githubusercontent.com/merlerm/kindergarden/pr-assets-kinder3d-fixes/docs/pr-assets/kinder3d-fixes/packing-before.gif) | ![Packing3D corrected 0.2 solution](https://raw.githubusercontent.com/merlerm/kindergarden/pr-assets-kinder3d-fixes/docs/pr-assets/kinder3d-fixes/packing-after.gif) |

Both recordings use seed `7138484576005690180`. The original trajectory terminates in six actions. The corrected trajectory uses 89 bounded, collision-valid actions and produces the separated terminal packing shown from above:

![Packing3D corrected terminal state from above](https://raw.githubusercontent.com/merlerm/kindergarden/pr-assets-kinder3d-fixes/docs/pr-assets/kinder3d-fixes/packing-after-top-down.png)

## Geometry and state restoration

The overlap test represents each implemented part component as a convex polyhedron and applies the separating axis theorem over face normals and edge cross products. The grasp pegs are included as separate components. Exact contact is allowed; only positive-volume overlap beyond the numerical tolerance is rejected.

The same shape-aware predicate is reused in three places:

- reset rejection sampling;
- held-object collision validation during motion; and
- terminal validation between packed parts and between each part and the rack.

Triangle states retain their PyBullet body-origin pose for serialization. Their geometric-center accessor rotates the local centroid offset into the world frame. `set_state()` recreates cuboids, triangles, and the rack from the state's type and dimension features, rebuilds all body-ID mappings, and then applies the stored origin poses. A normal reset restores the configured rack geometry.

Reset rejection sampling now raises an explicit error after exhausting its attempt limit instead of retaining the final colliding sample.

## Goal predicate

Success requires every part to be ungrasped and fully seated in the rack cavity:

- its complete main-body footprint is contained in the rack's local XY bounds;
- its bottom is at the rack floor within the placement tolerance;
- its top remains below the rack rim;
- it has rack support without strict rack overlap; and
- no pair of seated parts strictly overlaps.

## Test plan

- Focused Packing3D suite: **21 passed**, sharded into three processes to avoid a load-related exit 137.
- All **46** Kinematic3D test nodes passed across branch-scoped shards.
- Changed-file pylint: **passed**; mypy on all four changed source files: **passed**.
- Pairwise overlap coverage includes every combination of cuboid, right-triangular, and equilateral-triangular parts.
- Regressions cover held triangular parts, peg-only overlap, exact contact, mixed-shape reset sampling, rack overlap, hovering, and valid seating.
- State regressions verify repeated no-drift restoration, exact round trips for rotated right triangles, and state-defined cuboid, triangle, and rack dimensions, including rebuilt ID and feature mappings.
- An infeasible-reset regression verifies that exhausted rejection sampling raises `RuntimeError`.

## Stack

Top layer of native stack #139. Mechanically based on #137; its code changes otherwise depend on #135 and merged PR #88.
