### PR TITLE
Add limb object types and torque-control utilities

### DIFF
--- a/src/kinder/envs/dynamic3d/limb_object_types.py
+++ b/src/kinder/envs/dynamic3d/limb_object_types.py
@@ -1,0 +1,37 @@
+"""Object types for the limb repositioning environments."""
+
+from relational_structs import Type
+
+Limb3DEnvTypeFeatures: dict[Type, list[str]] = {}
+
+# Torque control means the state needs joint velocities as well as positions.
+Limb3DRobotType = Type("Limb3DRobot")
+Limb3DEnvTypeFeatures[Limb3DRobotType] = (
+    [
+        "pos_base_x",
+        "pos_base_y",
+        "pos_base_rot",
+    ]
+    + [f"joint_{i}" for i in range(1, 8)]
+    + [f"joint_vel_{i}" for i in range(1, 8)]
+)
+
+# A passive human limb (arm or leg) with 6 DOF.
+Limb3DLimbType = Type("Limb3DLimb")
+Limb3DEnvTypeFeatures[Limb3DLimbType] = (
+    [f"joint_{i}" for i in range(1, 7)]
+    + [f"joint_vel_{i}" for i in range(1, 7)]
+    + [f"goal_joint_{i}" for i in range(1, 7)]
+)
+
+# Fixtures are static scene objects with a pose, e.g., the wheelchair or the bed.
+Limb3DFixtureType = Type("Limb3DFixture")
+Limb3DEnvTypeFeatures[Limb3DFixtureType] = [
+    "pose_x",
+    "pose_y",
+    "pose_z",
+    "pose_qx",
+    "pose_qy",
+    "pose_qz",
+    "pose_qw",
+]

--- a/src/kinder/envs/dynamic3d/limb_utils.py
+++ b/src/kinder/envs/dynamic3d/limb_utils.py
@@ -1,0 +1,196 @@
+"""Utilities for the limb repositioning environments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypeAlias
+
+import numpy as np
+import pybullet as p
+from numpy.typing import NDArray
+from pybullet_helpers.geometry import SE2Pose
+from pybullet_helpers.joint import (
+    JointInfo,
+    JointPositions,
+    JointVelocities,
+    get_jointwise_difference,
+)
+from relational_structs import ObjectCentricState
+
+from kinder.envs.utils import RobotActionSpace
+
+JointTorques: TypeAlias = list[float]
+
+ASSETS_DIR = Path(__file__).parent / "assets"
+HUMAN_ASSETS_DIR = ASSETS_DIR / "human"
+NUM_ROBOT_JOINTS = 7
+NUM_LIMB_JOINTS = 6
+PYBULLET_TIMESTEP = 1.0 / 240.0
+
+
+def joint_position_distance(
+    joint_infos: list[JointInfo],
+    positions: JointPositions,
+    other: JointPositions,
+    weights: list[float] | None = None,
+) -> float:
+    """Weighted sum of per-joint differences, wrapping only the circular joints.
+
+    Matches the "weighted_joints" metric in pybullet_helpers.motion_planning.
+    """
+    difference = get_jointwise_difference(joint_infos, positions, other)
+    if weights is None:
+        weights = [1.0] * len(joint_infos)
+    return float(np.sum(np.multiply(weights, np.abs(difference))))
+
+
+def _circular_joint_info(index: int) -> JointInfo:
+    """A continuous joint, for callers with no physics client to query."""
+    # PyBullet marks circular joints with an upper limit below the lower limit.
+    return JointInfo(
+        jointIndex=index,
+        jointName=f"joint_{index}",
+        jointType=p.JOINT_REVOLUTE,
+        qIndex=-1,
+        uIndex=-1,
+        flags=0,
+        jointDamping=0.0,
+        jointFriction=0.0,
+        jointLowerLimit=0.0,
+        jointUpperLimit=-1.0,
+        jointMaxForce=0.0,
+        jointMaxVelocity=0.0,
+        linkName=f"link_{index}",
+        jointAxis=(0.0, 0.0, 1.0),
+        parentFramePos=(0.0, 0.0, 0.0),
+        parentFrameOrn=(0.0, 0.0, 0.0, 1.0),
+        parentIndex=-1,
+    )
+
+
+# Every limb URDF joint is continuous.
+LIMB_JOINT_INFOS = [_circular_joint_info(i) for i in range(NUM_LIMB_JOINTS)]
+
+
+class LimbRepositioning3DObjectCentricState(ObjectCentricState):
+    """A state in a limb repositioning environment.
+
+    Inherits from ObjectCentricState but adds some convenient look ups.
+    """
+
+    @property
+    def robot(self):
+        """Assumes there is a unique robot object named "robot"."""
+        return self.get_object_from_name("robot")
+
+    @property
+    def limb(self):
+        """Assumes there is a unique passive limb object named "limb"."""
+        return self.get_object_from_name("limb")
+
+    @property
+    def base_pose(self) -> SE2Pose:
+        """The SE2 pose of the robot's mobile base."""
+        return SE2Pose(
+            self.get(self.robot, "pos_base_x"),
+            self.get(self.robot, "pos_base_y"),
+            self.get(self.robot, "pos_base_rot"),
+        )
+
+    @property
+    def robot_joint_positions(self) -> JointPositions:
+        """The robot arm joint positions."""
+        return [
+            self.get(self.robot, f"joint_{i}") for i in range(1, NUM_ROBOT_JOINTS + 1)
+        ]
+
+    @property
+    def robot_joint_velocities(self) -> JointVelocities:
+        """The robot arm joint velocities."""
+        return [
+            self.get(self.robot, f"joint_vel_{i}")
+            for i in range(1, NUM_ROBOT_JOINTS + 1)
+        ]
+
+    @property
+    def limb_joint_positions(self) -> JointPositions:
+        """The passive limb joint positions."""
+        return [
+            self.get(self.limb, f"joint_{i}") for i in range(1, NUM_LIMB_JOINTS + 1)
+        ]
+
+    @property
+    def limb_joint_velocities(self) -> JointVelocities:
+        """The passive limb joint velocities."""
+        return [
+            self.get(self.limb, f"joint_vel_{i}") for i in range(1, NUM_LIMB_JOINTS + 1)
+        ]
+
+    @property
+    def limb_goal_joint_positions(self) -> JointPositions:
+        """The goal joint positions for the passive limb."""
+        return [
+            self.get(self.limb, f"goal_joint_{i}")
+            for i in range(1, NUM_LIMB_JOINTS + 1)
+        ]
+
+    @property
+    def limb_distance_to_goal(self) -> float:
+        """The distance in joint space between the limb and its goal."""
+        return joint_position_distance(
+            LIMB_JOINT_INFOS, self.limb_joint_positions, self.limb_goal_joint_positions
+        )
+
+
+class LimbRepositioning3DRobotActionSpace(RobotActionSpace):
+    """An action space for a torque-controlled 7 DOF robot arm.
+
+    Actions are torques applied to each of the arm joints. The mobile base does not move
+    during a repositioning episode, so it is not part of the action.
+    """
+
+    def __init__(
+        self,
+        torque_lower_limits: JointTorques,
+        torque_upper_limits: JointTorques,
+    ) -> None:
+        assert len(torque_lower_limits) == len(torque_upper_limits) == NUM_ROBOT_JOINTS
+        super().__init__(np.array(torque_lower_limits), np.array(torque_upper_limits))
+
+    def create_markdown_description(self) -> str:
+        """Create a markdown description with a table of action space entries."""
+        # Explicit newlines, since docformatter reflows triple-quoted literals.
+        lines = [
+            "An action space for a torque-controlled 7 DOF robot arm.",
+            "",
+            "Actions are torques on each arm joint, clipped to the environment's torque "
+            "limits. The base does not move, so it is not part of the action.",
+            "",
+            "| **Index** | **Description** |",
+            "| --- | --- |",
+        ]
+        lines += [
+            f"| {i - 1} | torque applied to robot joint {i} |"
+            for i in range(1, NUM_ROBOT_JOINTS + 1)
+        ]
+        return "\n".join(lines)
+
+
+def get_torque_action_from_gui_input(
+    action_space: LimbRepositioning3DRobotActionSpace, gui_input: dict
+) -> NDArray[np.float32]:
+    """Map human inputs to joint torques, for manual control and debugging.
+
+    Number keys 1-7 select a joint; the left stick's vertical axis sets the sign and
+    magnitude of the torque applied to it.
+    """
+    torques = np.zeros(NUM_ROBOT_JOINTS, dtype=np.float32)
+    keys_pressed = gui_input.get("keys", set())
+    _, left_y = gui_input.get("left_stick", (0.0, 0.0))
+    for i in range(NUM_ROBOT_JOINTS):
+        if str(i + 1) in keys_pressed:
+            scale = np.where(
+                left_y >= 0, action_space.high[i], -action_space.low[i]
+            ).item()
+            torques[i] = left_y * scale
+    return torques

--- a/tests/envs/dynamic3d/test_limb_utils.py
+++ b/tests/envs/dynamic3d/test_limb_utils.py
@@ -1,0 +1,219 @@
+"""Tests for the limb object types and the torque-control utilities."""
+
+import numpy as np
+import pytest
+from relational_structs import Object
+from relational_structs.utils import create_state_from_dict
+
+from kinder.envs.dynamic3d.limb_object_types import (
+    Limb3DEnvTypeFeatures,
+    Limb3DFixtureType,
+    Limb3DLimbType,
+    Limb3DRobotType,
+)
+from kinder.envs.dynamic3d.limb_utils import (
+    LIMB_JOINT_INFOS,
+    NUM_LIMB_JOINTS,
+    NUM_ROBOT_JOINTS,
+    LimbRepositioning3DObjectCentricState,
+    LimbRepositioning3DRobotActionSpace,
+    get_torque_action_from_gui_input,
+    joint_position_distance,
+)
+
+
+def _limited_joint_info(index: int):
+    """A joint with finite limits, which must not be wrapped."""
+    return LIMB_JOINT_INFOS[index]._replace(jointLowerLimit=-2.66, jointUpperLimit=2.66)
+
+
+def _make_state(
+    limb_joints,
+    goal_joints,
+    limb_velocities=None,
+    robot_joints=None,
+    base=(0.0, 0.0, 0.0),
+):
+    """Build a state with one robot and one limb, for the property lookups."""
+    limb_velocities = limb_velocities or [0.0] * NUM_LIMB_JOINTS
+    robot_joints = robot_joints or [0.0] * NUM_ROBOT_JOINTS
+    robot_feats = {
+        "pos_base_x": base[0],
+        "pos_base_y": base[1],
+        "pos_base_rot": base[2],
+    }
+    for i, value in enumerate(robot_joints):
+        robot_feats[f"joint_{i + 1}"] = value
+        robot_feats[f"joint_vel_{i + 1}"] = 0.0
+    limb_feats = {}
+    for i in range(NUM_LIMB_JOINTS):
+        limb_feats[f"joint_{i + 1}"] = limb_joints[i]
+        limb_feats[f"joint_vel_{i + 1}"] = limb_velocities[i]
+        limb_feats[f"goal_joint_{i + 1}"] = goal_joints[i]
+    state = create_state_from_dict(
+        {
+            Object("robot", Limb3DRobotType): robot_feats,
+            Object("limb", Limb3DLimbType): limb_feats,
+        },
+        Limb3DEnvTypeFeatures,
+        state_cls=LimbRepositioning3DObjectCentricState,
+    )
+    assert isinstance(state, LimbRepositioning3DObjectCentricState)
+    return state
+
+
+def test_object_type_feature_counts():
+    """The types carry positions and velocities for torque control."""
+    assert len(Limb3DEnvTypeFeatures[Limb3DRobotType]) == 3 + 2 * NUM_ROBOT_JOINTS
+    assert len(Limb3DEnvTypeFeatures[Limb3DLimbType]) == 3 * NUM_LIMB_JOINTS
+    assert len(Limb3DEnvTypeFeatures[Limb3DFixtureType]) == 7
+
+
+def test_joint_position_distance_is_zero_for_identical_configurations():
+    """A configuration is zero distance from itself."""
+    positions = [0.1, -0.2, 0.3, 1.0, -1.0, 0.0]
+    assert joint_position_distance(
+        LIMB_JOINT_INFOS, positions, positions
+    ) == pytest.approx(0.0)
+
+
+def test_joint_position_distance_wraps_a_full_turn():
+    """A circular joint wound a full turn counts as being where it looks."""
+    positions = [0.0] * NUM_LIMB_JOINTS
+    wound = [2 * np.pi] + [0.0] * (NUM_LIMB_JOINTS - 1)
+    assert joint_position_distance(LIMB_JOINT_INFOS, positions, wound) == pytest.approx(
+        0.0, abs=1e-9
+    )
+
+
+def test_joint_position_distance_takes_the_short_way_around():
+    """Crossing pi is measured the short way, not the long way."""
+    a = [0.9 * np.pi] + [0.0] * (NUM_LIMB_JOINTS - 1)
+    b = [-0.9 * np.pi] + [0.0] * (NUM_LIMB_JOINTS - 1)
+    assert joint_position_distance(LIMB_JOINT_INFOS, a, b) == pytest.approx(0.2 * np.pi)
+
+
+def test_joint_position_distance_sums_over_joints():
+    """Per-joint differences combine as a weighted sum of absolute values."""
+    a = [0.0] * NUM_LIMB_JOINTS
+    b = [0.3, 0.4] + [0.0] * (NUM_LIMB_JOINTS - 2)
+    assert joint_position_distance(LIMB_JOINT_INFOS, a, b) == pytest.approx(0.7)
+
+
+def test_joint_position_distance_applies_weights():
+    """Weights scale each joint's contribution."""
+    a = [0.0] * NUM_LIMB_JOINTS
+    b = [0.3, 0.4] + [0.0] * (NUM_LIMB_JOINTS - 2)
+    weights = [2.0, 0.5] + [1.0] * (NUM_LIMB_JOINTS - 2)
+    assert joint_position_distance(
+        LIMB_JOINT_INFOS, a, b, weights=weights
+    ) == pytest.approx(0.8)
+
+
+def test_joint_position_distance_does_not_wrap_limited_joints():
+    """A limited joint cannot pass through the wrap point, so it is not wrapped."""
+    limited = [_limited_joint_info(i) for i in range(NUM_LIMB_JOINTS)]
+    a = [2.6] + [0.0] * (NUM_LIMB_JOINTS - 1)
+    b = [-2.6] + [0.0] * (NUM_LIMB_JOINTS - 1)
+    assert joint_position_distance(limited, a, b) == pytest.approx(5.2)
+    assert joint_position_distance(LIMB_JOINT_INFOS, a, b) == pytest.approx(
+        2 * np.pi - 5.2
+    )
+
+
+def test_action_space_shape_and_bounds():
+    """The action space is one torque per arm joint, within the given limits."""
+    space = LimbRepositioning3DRobotActionSpace(
+        [-2.0] * NUM_ROBOT_JOINTS, [3.0] * NUM_ROBOT_JOINTS
+    )
+    assert space.shape == (NUM_ROBOT_JOINTS,)
+    assert np.all(space.low == -2.0)
+    assert np.all(space.high == 3.0)
+    for _ in range(5):
+        assert space.contains(space.sample())
+
+
+def test_action_space_rejects_mismatched_limits():
+    """Limits that are not one per arm joint are a programming error."""
+    with pytest.raises(AssertionError):
+        LimbRepositioning3DRobotActionSpace([-1.0], [1.0])
+
+
+def test_action_space_markdown_has_a_row_per_joint():
+    """The generated docs table describes every joint torque."""
+    space = LimbRepositioning3DRobotActionSpace(
+        [-1.0] * NUM_ROBOT_JOINTS, [1.0] * NUM_ROBOT_JOINTS
+    )
+    description = space.create_markdown_description()
+    assert "| **Index** | **Description** |" in description
+    for i in range(1, NUM_ROBOT_JOINTS + 1):
+        assert f"| {i - 1} | torque applied to robot joint {i} |" in description
+
+
+def test_gui_input_is_zero_without_a_selected_joint():
+    """No number key held means no torque."""
+    space = LimbRepositioning3DRobotActionSpace(
+        [-1.0] * NUM_ROBOT_JOINTS, [1.0] * NUM_ROBOT_JOINTS
+    )
+    action = get_torque_action_from_gui_input(
+        space, {"keys": set(), "left_stick": (0.0, 1.0)}
+    )
+    assert np.all(action == 0.0)
+
+
+def test_gui_input_drives_only_the_selected_joint():
+    """Holding a number key applies torque to that joint alone."""
+    space = LimbRepositioning3DRobotActionSpace(
+        [-1.0] * NUM_ROBOT_JOINTS, [2.0] * NUM_ROBOT_JOINTS
+    )
+    action = get_torque_action_from_gui_input(
+        space, {"keys": {"3"}, "left_stick": (0.0, 1.0)}
+    )
+    assert action[2] == pytest.approx(2.0)
+    assert np.all(np.delete(action, 2) == 0.0)
+
+
+def test_gui_input_scales_by_the_matching_limit_sign():
+    """A negative stick scales by the lower limit, so the torque stays in bounds."""
+    space = LimbRepositioning3DRobotActionSpace(
+        [-4.0] * NUM_ROBOT_JOINTS, [2.0] * NUM_ROBOT_JOINTS
+    )
+    action = get_torque_action_from_gui_input(
+        space, {"keys": {"1"}, "left_stick": (0.0, -1.0)}
+    )
+    assert action[0] == pytest.approx(-4.0)
+    assert space.contains(action)
+
+
+def test_state_exposes_limb_and_robot_joints():
+    """The convenience properties read back what was written."""
+    limb_joints = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+    goal_joints = [0.0] * NUM_LIMB_JOINTS
+    velocities = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    robot_joints = [0.7] * NUM_ROBOT_JOINTS
+    state = _make_state(
+        limb_joints, goal_joints, velocities, robot_joints, base=(1.0, 2.0, 0.5)
+    )
+    assert np.allclose(state.limb_joint_positions, limb_joints)
+    assert np.allclose(state.limb_goal_joint_positions, goal_joints)
+    assert np.allclose(state.limb_joint_velocities, velocities)
+    assert np.allclose(state.robot_joint_positions, robot_joints)
+    assert np.allclose(state.robot_joint_velocities, [0.0] * NUM_ROBOT_JOINTS)
+    assert state.base_pose.x == pytest.approx(1.0)
+    assert state.base_pose.y == pytest.approx(2.0)
+    assert state.base_pose.rot == pytest.approx(0.5)
+
+
+def test_state_distance_to_goal_matches_joint_distance():
+    """limb_distance_to_goal is the wrap-aware distance between limb and goal."""
+    limb_joints = [0.3, 0.4, 0.0, 0.0, 0.0, 0.0]
+    goal_joints = [0.0] * NUM_LIMB_JOINTS
+    state = _make_state(limb_joints, goal_joints)
+    assert state.limb_distance_to_goal == pytest.approx(0.7)
+
+
+def test_state_distance_to_goal_is_zero_at_the_goal():
+    """A limb sitting on its goal is zero distance away."""
+    goal_joints = [0.1, -0.2, 0.3, 0.4, -0.5, 0.6]
+    state = _make_state(list(goal_joints), goal_joints)
+    assert state.limb_distance_to_goal == pytest.approx(0.0)


### PR DESCRIPTION
Object types for the robot, the passive limb, and static fixtures, plus the torque
action space, the wrap-aware joint distance, and a state class with convenience lookups
for limb and robot joints.

Torque control means the state carries joint velocities as well as positions, so these
types differ from the rest of Kinematic3D.

Tests: `tests/envs/kinematic3d/test_limb_utils.py` (14 tests) covers joint-distance
wrapping, the action space and its generated docs table, the GUI torque mapping, and the
state properties.
