### PR TITLE
Add passive human limb models

### DIFF
--- a/src/kinder/envs/dynamic3d/limbs.py
+++ b/src/kinder/envs/dynamic3d/limbs.py
@@ -1,0 +1,307 @@
+"""PyBullet models of the human limbs that the robot repositions, and the joint limit
+and muscle tone models that describe how they resist being moved.
+
+These differ from the human models bundled with pybullet_helpers: some joint axes are
+flipped, the joints are continuous, and the grasp frame is placed differently.
+"""
+
+import abc
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+from pybullet_helpers.geometry import Pose
+from pybullet_helpers.joint import JointPositions, JointVelocities
+from pybullet_helpers.robots.single_arm import SingleArmPyBulletRobot
+
+from kinder.envs.dynamic3d.limb_utils import HUMAN_ASSETS_DIR, JointTorques
+
+
+class BaseJointLimitsModel(abc.ABC):
+    """Base model for joint limits."""
+
+    @abc.abstractmethod
+    def check_joint_limits(self, joint_positions: JointPositions) -> bool:
+        """Check if the given joint positions are within the limits."""
+
+
+class NoJointLimitsModel(BaseJointLimitsModel):
+    """A model where every joint position is allowed."""
+
+    def check_joint_limits(self, joint_positions: JointPositions) -> bool:
+        del joint_positions
+        return True
+
+
+class BoxJointLimitsModel(BaseJointLimitsModel):
+    """A model where each joint is independently bounded.
+
+    A no-op on the limbs, whose URDF joints are continuous, so the bounds are +/-inf.
+    """
+
+    def __init__(
+        self, lower_limits: JointPositions, upper_limits: JointPositions
+    ) -> None:
+        self._lower_limits = lower_limits
+        self._upper_limits = upper_limits
+
+    def check_joint_limits(self, joint_positions: JointPositions) -> bool:
+        return all(
+            lower <= v <= upper
+            for lower, v, upper in zip(
+                self._lower_limits,
+                joint_positions,
+                self._upper_limits,
+                strict=True,
+            )
+        )
+
+
+def create_joint_limits_model(
+    name: str, lower_limits: JointPositions, upper_limits: JointPositions
+) -> BaseJointLimitsModel:
+    """Create a joint limits model from its name."""
+    if name == "none":
+        return NoJointLimitsModel()
+    if name == "box":
+        return BoxJointLimitsModel(lower_limits, upper_limits)
+    raise ValueError(f"Unrecognized joint limits model: {name}")
+
+
+# The limb URDFs use continuous joints, so anatomical bounds are given here instead.
+_BALL_RANGE = (-np.pi / 2, np.pi / 2)
+_DISTAL_RANGE = (-np.pi / 4, np.pi / 4)
+_ELBOW_FLEXION = 2.53  # 145 degrees
+_KNEE_FLEXION = 2.36  # 135 degrees
+
+_HINGE_RANGES: dict[str, tuple[float, float]] = {
+    "human-left-arm": (0.0, _ELBOW_FLEXION),
+    "human-right-arm": (-_ELBOW_FLEXION, 0.0),
+    "human-left-leg": (0.0, _KNEE_FLEXION),
+    "human-right-leg": (0.0, _KNEE_FLEXION),
+}
+
+
+def get_sampling_bounds(
+    limb_name: str, nominal: NDArray[np.float64]
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Joint ranges widened to contain a nominal configuration that sits outside
+    them."""
+    lower, upper = np.array(get_human_joint_ranges(limb_name)).T
+    return np.minimum(lower, nominal), np.maximum(upper, nominal)
+
+
+def get_human_joint_ranges(limb_name: str) -> tuple[tuple[float, float], ...]:
+    """Per-joint bounds for a human limb, in URDF joint coordinates."""
+    if limb_name not in _HINGE_RANGES:
+        raise ValueError(f"Unknown human limb: {limb_name}")
+    return (
+        _BALL_RANGE,
+        _BALL_RANGE,
+        _BALL_RANGE,
+        _HINGE_RANGES[limb_name],
+        _DISTAL_RANGE,
+        _DISTAL_RANGE,
+    )
+
+
+class BaseMuscleToneModel(abc.ABC):
+    """Base muscle tone model."""
+
+    @abc.abstractmethod
+    def get_muscle_tone(
+        self, joint_positions: JointPositions, joint_velocities: JointVelocities
+    ) -> JointTorques:
+        """Get the torque that the limb currently applies to itself."""
+
+
+class NoMuscleToneModel(BaseMuscleToneModel):
+    """A completely limp limb."""
+
+    def get_muscle_tone(
+        self, joint_positions: JointPositions, joint_velocities: JointVelocities
+    ) -> JointTorques:
+        num_joints = len(joint_positions)
+        assert num_joints == len(joint_velocities)
+        return [0.0] * num_joints
+
+
+class SpringMuscleToneModel(BaseMuscleToneModel):
+    """A spring-damper muscle tone model.
+
+    Unvalidated: the tone is clamped to be one-directional and can exceed the robot's
+    torque limit.
+    """
+
+    def __init__(self, num_joints: int) -> None:
+        self._num_joints = num_joints
+        # Placeholders that should eventually be sampled rather than hard-coded.
+        self._b = -1 * np.ones(num_joints)
+        self._k = np.eye(num_joints)
+        self._m = 0.5 * np.ones(num_joints)
+        self._c = 0.1 * np.ones(num_joints)
+
+    def get_muscle_tone(
+        self, joint_positions: JointPositions, joint_velocities: JointVelocities
+    ) -> JointTorques:
+        tone = np.maximum(
+            np.zeros(self._num_joints),
+            -(self._b - self._k @ np.abs(np.subtract(joint_positions, self._m)))
+            - self._c * np.asarray(joint_velocities),
+        )
+        return list(tone)
+
+
+def create_muscle_tone_model(name: str, num_joints: int) -> BaseMuscleToneModel:
+    """Create a muscle tone model from its name."""
+    if name == "none":
+        return NoMuscleToneModel()
+    if name == "spring":
+        return SpringMuscleToneModel(num_joints)
+    raise ValueError(f"Unrecognized muscle tone model: {name}")
+
+
+class HumanLimbPyBulletRobot(SingleArmPyBulletRobot):
+    """Base class for a passive human limb.
+
+    A limb is modelled as a robot, but is never commanded directly: it moves only in
+    response to the forces the robot transmits through the grasp, plus its muscle tone.
+    """
+
+    def __init__(
+        self,
+        *args,
+        joint_limits_model_name: str = "none",
+        muscle_tone_model_name: str = "none",
+        **kwargs,
+    ) -> None:
+        # The base __init__ calls check_joint_limits() before the model exists.
+        self._joint_limits_model_created = False
+        super().__init__(*args, **kwargs)
+        self._joint_limits_model = self._create_joint_limits_model(
+            joint_limits_model_name
+        )
+        self._joint_limits_model_created = True
+        self._muscle_tone_model = create_muscle_tone_model(
+            muscle_tone_model_name, len(self.arm_joints)
+        )
+
+    def _create_joint_limits_model(self, name: str) -> BaseJointLimitsModel:
+        return create_joint_limits_model(
+            name, self.joint_lower_limits, self.joint_upper_limits
+        )
+
+    def check_joint_limits(self, joint_positions: JointPositions) -> bool:
+        if not self._joint_limits_model_created:
+            return super().check_joint_limits(joint_positions)
+        return self._joint_limits_model.check_joint_limits(joint_positions)
+
+    @property
+    def muscle_tone_model(self) -> BaseMuscleToneModel:
+        """The muscle tone model for this limb."""
+        return self._muscle_tone_model
+
+    def get_muscle_tone_torque(self) -> JointTorques:
+        """The torque the limb currently applies to itself."""
+        pos = self.get_joint_positions()
+        vel = self.get_joint_velocities()
+        return self._muscle_tone_model.get_muscle_tone(pos, vel)
+
+    @property
+    def end_effector_name(self) -> str:
+        return "grasp_fixed_joint"
+
+    @property
+    def tool_link_name(self) -> str:
+        return "ee_link"
+
+
+class HumanLeftArm(HumanLimbPyBulletRobot):
+    """Human left arm."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "human-left-arm"
+
+    @property
+    def default_urdf_path(self) -> Path:
+        return HUMAN_ASSETS_DIR / "left_arm_6dof_continuous.urdf"
+
+    @property
+    def default_home_joint_positions(self) -> JointPositions:
+        return [0.0, -0.1, 0.1, -1.08786023, 0.0, 0.0]
+
+
+class HumanRightArm(HumanLimbPyBulletRobot):
+    """Human right arm."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "human-right-arm"
+
+    @property
+    def default_urdf_path(self) -> Path:
+        return HUMAN_ASSETS_DIR / "right_arm_6dof_continuous.urdf"
+
+    @property
+    def default_home_joint_positions(self) -> JointPositions:
+        return [0.0, 0.1, 0.1, -1.08786023, 0.0, 0.0]
+
+
+class HumanLeftLeg(HumanLimbPyBulletRobot):
+    """Human left leg."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "human-left-leg"
+
+    @property
+    def default_urdf_path(self) -> Path:
+        return HUMAN_ASSETS_DIR / "left_leg_6dof_continuous.urdf"
+
+    @property
+    def default_home_joint_positions(self) -> JointPositions:
+        return [0.0, -0.1, 0.1, -1.08786023, -0.14448669, -0.26559232]
+
+
+class HumanRightLeg(HumanLimbPyBulletRobot):
+    """Human right leg."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "human-right-leg"
+
+    @property
+    def default_urdf_path(self) -> Path:
+        return HUMAN_ASSETS_DIR / "right_leg_6dof_continuous.urdf"
+
+    @property
+    def default_home_joint_positions(self) -> JointPositions:
+        return [0.0, -0.1, 0.1, -1.08786023, -0.14448669, -0.26559232]
+
+
+LIMB_NAME_TO_CLS: dict[str, type[HumanLimbPyBulletRobot]] = {
+    cls.get_name(): cls
+    for cls in (HumanLeftArm, HumanRightArm, HumanLeftLeg, HumanRightLeg)
+}
+ALL_LIMB_NAMES = tuple(LIMB_NAME_TO_CLS)
+
+
+def create_human_limb(
+    name: str,
+    base_pose: Pose,
+    home_joint_positions: JointPositions | None,
+    joint_limits_model_name: str,
+    muscle_tone_model_name: str,
+    physics_client_id: int,
+) -> HumanLimbPyBulletRobot:
+    """Create a human limb from its name."""
+    if name not in LIMB_NAME_TO_CLS:
+        raise ValueError(f"Unknown human limb: {name}")
+    return LIMB_NAME_TO_CLS[name](
+        physics_client_id=physics_client_id,
+        base_pose=base_pose,
+        home_joint_positions=home_joint_positions,
+        joint_limits_model_name=joint_limits_model_name,
+        muscle_tone_model_name=muscle_tone_model_name,
+    )

--- a/tests/envs/dynamic3d/test_limbs.py
+++ b/tests/envs/dynamic3d/test_limbs.py
@@ -1,0 +1,216 @@
+"""Tests for limbs.py."""
+
+import numpy as np
+import pybullet as p
+import pytest
+from pybullet_helpers.geometry import Pose
+
+from kinder.envs.dynamic3d.limbs import (
+    ALL_LIMB_NAMES,
+    LIMB_NAME_TO_CLS,
+    BoxJointLimitsModel,
+    HumanLimbPyBulletRobot,
+    NoJointLimitsModel,
+    NoMuscleToneModel,
+    SpringMuscleToneModel,
+    create_human_limb,
+    create_joint_limits_model,
+    create_muscle_tone_model,
+    get_human_joint_ranges,
+    get_sampling_bounds,
+)
+from kinder.envs.dynamic3d.limb_utils import NUM_LIMB_JOINTS
+
+
+@pytest.fixture(name="physics_client_id")
+def _physics_client_id():
+    """A headless PyBullet connection, torn down after each test."""
+    client_id = p.connect(p.DIRECT)
+    yield client_id
+    p.disconnect(physicsClientId=client_id)
+
+
+def test_all_four_limbs_are_registered():
+    """There is one class per arm and leg, keyed by name."""
+    assert set(ALL_LIMB_NAMES) == {
+        "human-left-arm",
+        "human-right-arm",
+        "human-left-leg",
+        "human-right-leg",
+    }
+    for name in ALL_LIMB_NAMES:
+        assert LIMB_NAME_TO_CLS[name].get_name() == name
+
+
+def test_no_joint_limits_model_allows_everything():
+    """The default model is a no-op, matching the URDFs' continuous joints."""
+    model = NoJointLimitsModel()
+    assert model.check_joint_limits([1e6] * NUM_LIMB_JOINTS)
+
+
+def test_box_joint_limits_model_bounds_each_joint():
+    """Each joint is checked independently against its own bounds."""
+    model = BoxJointLimitsModel([-1.0] * NUM_LIMB_JOINTS, [1.0] * NUM_LIMB_JOINTS)
+    assert model.check_joint_limits([0.0] * NUM_LIMB_JOINTS)
+    assert model.check_joint_limits([1.0] * NUM_LIMB_JOINTS)
+    assert not model.check_joint_limits([0.0, 0.0, 0.0, 0.0, 0.0, 1.5])
+    assert not model.check_joint_limits([-1.5, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+
+def test_create_joint_limits_model_by_name():
+    """The factory maps names to models and rejects anything else."""
+    lower, upper = [-1.0] * NUM_LIMB_JOINTS, [1.0] * NUM_LIMB_JOINTS
+    assert isinstance(
+        create_joint_limits_model("none", lower, upper), NoJointLimitsModel
+    )
+    assert isinstance(
+        create_joint_limits_model("box", lower, upper), BoxJointLimitsModel
+    )
+    with pytest.raises(ValueError, match="Unrecognized joint limits model"):
+        create_joint_limits_model("nonsense", lower, upper)
+
+
+def test_no_muscle_tone_model_is_limp():
+    """A limp limb applies no torque to itself."""
+    model = NoMuscleToneModel()
+    tone = model.get_muscle_tone([0.5] * NUM_LIMB_JOINTS, [0.1] * NUM_LIMB_JOINTS)
+    assert tone == [0.0] * NUM_LIMB_JOINTS
+
+
+def test_spring_muscle_tone_model_is_one_directional():
+    """The spring model is clamped at zero, so it never pulls negative."""
+    model = SpringMuscleToneModel(NUM_LIMB_JOINTS)
+    for positions in ([0.0] * NUM_LIMB_JOINTS, [2.0] * NUM_LIMB_JOINTS):
+        tone = model.get_muscle_tone(positions, [0.0] * NUM_LIMB_JOINTS)
+        assert len(tone) == NUM_LIMB_JOINTS
+        assert all(value >= 0.0 for value in tone)
+
+
+def test_spring_muscle_tone_grows_with_displacement():
+    """Pushing the limb further from its rest point meets more resistance."""
+    model = SpringMuscleToneModel(NUM_LIMB_JOINTS)
+    velocities = [0.0] * NUM_LIMB_JOINTS
+    near = sum(model.get_muscle_tone([0.5] * NUM_LIMB_JOINTS, velocities))
+    far = sum(model.get_muscle_tone([3.0] * NUM_LIMB_JOINTS, velocities))
+    assert far > near
+
+
+def test_create_muscle_tone_model_by_name():
+    """The factory maps names to models and rejects anything else."""
+    assert isinstance(
+        create_muscle_tone_model("none", NUM_LIMB_JOINTS), NoMuscleToneModel
+    )
+    assert isinstance(
+        create_muscle_tone_model("spring", NUM_LIMB_JOINTS), SpringMuscleToneModel
+    )
+    with pytest.raises(ValueError, match="Unrecognized muscle tone model"):
+        create_muscle_tone_model("nonsense", NUM_LIMB_JOINTS)
+
+
+@pytest.mark.parametrize("limb_name", ALL_LIMB_NAMES)
+def test_joint_ranges_are_well_formed(limb_name):
+    """Every limb has one ordered range per joint."""
+    ranges = get_human_joint_ranges(limb_name)
+    assert len(ranges) == NUM_LIMB_JOINTS
+    for lower, upper in ranges:
+        assert lower <= upper
+
+
+def test_joint_ranges_reject_unknown_limbs():
+    """An unknown limb name is an error rather than a silent default."""
+    with pytest.raises(ValueError, match="Unknown human limb"):
+        get_human_joint_ranges("human-third-arm")
+
+
+def test_elbow_and_knee_bend_one_way():
+    """The hinge joint is one-directional, and mirrored between left and right arms."""
+    left_arm = get_human_joint_ranges("human-left-arm")[3]
+    right_arm = get_human_joint_ranges("human-right-arm")[3]
+    assert left_arm[0] == 0.0 and left_arm[1] > 0.0
+    assert right_arm[0] < 0.0 and right_arm[1] == 0.0
+    for leg in ("human-left-leg", "human-right-leg"):
+        knee = get_human_joint_ranges(leg)[3]
+        assert knee[0] == 0.0 and knee[1] > 0.0
+
+
+@pytest.mark.parametrize("limb_name", ALL_LIMB_NAMES)
+def test_sampling_bounds_contain_the_nominal_configuration(limb_name):
+    """Bounds are widened so a nominal pose outside the anatomical range still fits."""
+    nominal = np.full(NUM_LIMB_JOINTS, 5.0)
+    lower, upper = get_sampling_bounds(limb_name, nominal)
+    assert np.all(lower <= nominal)
+    assert np.all(nominal <= upper)
+
+
+@pytest.mark.parametrize("limb_name", ALL_LIMB_NAMES)
+def test_sampling_bounds_keep_the_anatomical_range(limb_name):
+    """A nominal pose inside the range leaves the range untouched."""
+    nominal = np.zeros(NUM_LIMB_JOINTS)
+    lower, upper = get_sampling_bounds(limb_name, nominal)
+    ranges = np.array(get_human_joint_ranges(limb_name))
+    assert np.all(lower <= ranges[:, 0])
+    assert np.all(upper >= ranges[:, 1])
+
+
+@pytest.mark.parametrize("limb_name", ALL_LIMB_NAMES)
+def test_create_human_limb(limb_name, physics_client_id):
+    """Every limb loads with six joints and the grasp frame the weld needs."""
+    limb = create_human_limb(
+        limb_name,
+        Pose.identity(),
+        None,
+        "none",
+        "none",
+        physics_client_id,
+    )
+    assert isinstance(limb, HumanLimbPyBulletRobot)
+    assert len(limb.arm_joints) == NUM_LIMB_JOINTS
+    assert limb.end_effector_name == "grasp_fixed_joint"
+    assert limb.tool_link_name == "ee_link"
+    assert limb.get_end_effector_pose() is not None
+
+
+def test_create_human_limb_rejects_unknown_names(physics_client_id):
+    """An unknown limb name is an error rather than a silent default."""
+    with pytest.raises(ValueError, match="Unknown human limb"):
+        create_human_limb(
+            "human-third-arm",
+            Pose.identity(),
+            None,
+            "none",
+            "none",
+            physics_client_id,
+        )
+
+
+@pytest.mark.parametrize("limb_name", ALL_LIMB_NAMES)
+def test_limb_starts_at_its_home_joint_positions(limb_name, physics_client_id):
+    """Passing home joint positions places the limb there."""
+    home = [0.1, 0.2, 0.3, -0.4, 0.5, -0.6]
+    limb = create_human_limb(
+        limb_name, Pose.identity(), home, "none", "none", physics_client_id
+    )
+    assert np.allclose(limb.get_joint_positions(), home, atol=1e-6)
+
+
+def test_limb_muscle_tone_torque_matches_its_model(physics_client_id):
+    """A limp limb reports no self-torque; a spring limb reports some."""
+    limp = create_human_limb(
+        "human-left-arm", Pose.identity(), None, "none", "none", physics_client_id
+    )
+    assert limp.get_muscle_tone_torque() == [0.0] * NUM_LIMB_JOINTS
+
+    springy = create_human_limb(
+        "human-right-arm", Pose.identity(), None, "none", "spring", physics_client_id
+    )
+    assert isinstance(springy.muscle_tone_model, SpringMuscleToneModel)
+    assert len(springy.get_muscle_tone_torque()) == NUM_LIMB_JOINTS
+
+
+def test_box_joint_limits_apply_to_a_loaded_limb(physics_client_id):
+    """The limb defers to its joint limits model once construction has finished."""
+    limb = create_human_limb(
+        "human-left-arm", Pose.identity(), None, "box", "none", physics_client_id
+    )
+    # The URDF joints are continuous, so the box bounds are infinite and admit anything.
+    assert limb.check_joint_limits([1e6] * NUM_LIMB_JOINTS)


### PR DESCRIPTION
PyBullet models of the human limbs the robot repositions, with the joint limit and
muscle tone models describing how they resist being moved.

These differ from the human models bundled with pybullet_helpers: some joint axes are
flipped, the joints are continuous, and the grasp frame is placed differently.

Tests: `tests/envs/kinematic3d/test_limbs.py` (33 tests) covers both joint-limit models,
both muscle-tone models, the factories and their error paths, the anatomical joint
ranges, and loading all four limbs in PyBullet.
