### PR TITLE
Add limb repositioning scenes

### DIFF
--- a/src/kinder/envs/dynamic3d/limb_scenes.py
+++ b/src/kinder/envs/dynamic3d/limb_scenes.py
@@ -1,0 +1,379 @@
+"""Scenes that a human limb can be repositioned in.
+
+There are four kinds of scene, in increasing order of clutter:
+
+* isolated: the limb floats in an empty world, with no body attached.
+* human: the limb is attached to a torso, along with the three other limbs.
+* wheelchair: a human seated in a wheelchair, in a room.
+* bed: a human lying on a hospital bed, in a room.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pybullet as p
+from pybullet_helpers.geometry import Pose, multiply_poses, set_pose
+from pybullet_helpers.utils import create_pybullet_block
+
+from kinder.envs.dynamic3d.limb_utils import ASSETS_DIR, NUM_LIMB_JOINTS
+from kinder.envs.dynamic3d.limbs import (
+    ALL_LIMB_NAMES,
+    HumanLimbPyBulletRobot,
+    create_human_limb,
+)
+
+# Offsets from a limb's grasp frame to the robot's end effector
+_GRIPPER_APPROACH_SPIN = Pose.from_rpy((0.0, 0.0, 0.0), (0.0, 0.0, np.pi / 2))
+ARM_GRASP_TRANSFORM = multiply_poses(
+    Pose.from_rpy((0.0, 0.0, 0.0), (0.0, -np.pi / 2, 0.0)), _GRIPPER_APPROACH_SPIN
+)
+LEG_GRASP_TRANSFORM = multiply_poses(
+    Pose.from_rpy((0.0, 0.0, 0.0), (0.0, -np.pi / 2, -np.pi / 2)),
+    _GRIPPER_APPROACH_SPIN,
+)
+
+_RESTING_JOINTS = (0.0,) * NUM_LIMB_JOINTS
+
+
+@dataclass(frozen=True)
+class LimbRepositioningSceneConfig:
+    """Static description of a scene: what is in it and where."""
+
+    # One of "isolated", "human", "wheelchair", "bed".
+    scene_type: str
+    # The limb being repositioned, e.g. "human-left-arm".
+    limb_name: str
+    limb_init_joint_positions: tuple[float, ...]
+    limb_goal_joint_positions: tuple[float, ...]
+    limb_joint_limits_model_name: str = "none"
+    limb_muscle_tone_model_name: str = "none"
+
+    torso_base_pose: Pose = Pose.identity()
+    limb_base_pose: Pose = Pose.identity()
+    use_limb_pose_to_initialize: bool = False
+
+    # Resting joint positions of the limbs that are not being repositioned.
+    left_arm_init_joint_positions: tuple[float, ...] = _RESTING_JOINTS
+    right_arm_init_joint_positions: tuple[float, ...] = _RESTING_JOINTS
+    left_leg_init_joint_positions: tuple[float, ...] = _RESTING_JOINTS
+    right_leg_init_joint_positions: tuple[float, ...] = _RESTING_JOINTS
+
+    # Where each limb attaches to the torso.
+    torso_to_left_arm: Pose = Pose.from_rpy((0.24, 0.048, 0.45), (0.0, 0.0, 0.0))
+    torso_to_right_arm: Pose = Pose.from_rpy((-0.24, 0.048, 0.45), (0.0, 0.0, 0.0))
+    torso_to_left_leg: Pose = Pose.from_rpy((0.11, 0.0, 0.0), (0.0, 0.0, 0.0))
+    torso_to_right_leg: Pose = Pose.from_rpy((-0.11, 0.0, 0.0), (0.0, 0.0, 0.0))
+
+    # Room, used by the wheelchair and bed scenes.
+    floor_position: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    wall_poses: tuple[Pose, ...] = (
+        Pose.from_rpy((0.0, 2.5, 0.0), (np.pi / 2, 0.0, np.pi / 2)),
+        Pose.from_rpy((3.0, 0.0, 0.0), (np.pi / 2, 0.0, 0.0)),
+        Pose.from_rpy((-3.0, 0.0, 0.0), (np.pi / 2, 0.0, 0.0)),
+    )
+    wall_half_extents: tuple[float, float, float] = (0.1, 3.0, 5.0)
+
+    # Furniture.
+    wheelchair_pose: Pose = Pose.from_rpy((0.0, 0.0, 0.0), (0.0, 0.0, 0.0))
+    bed_pose: Pose = Pose.from_rpy((0.0, 0.0, 0.6), (0.0, 0.0, 0.0))
+
+    # Visualization of the goal configuration of the limb.
+    show_goal: bool = True
+    goal_rgba: tuple[float, float, float, float] = (0.0, 1.0, 0.0, 0.5)
+
+    def __post_init__(self) -> None:
+        assert self.scene_type in ALL_SCENE_TYPES
+        assert self.limb_name in ALL_LIMB_NAMES
+        assert len(self.limb_init_joint_positions) == NUM_LIMB_JOINTS
+        assert len(self.limb_goal_joint_positions) == NUM_LIMB_JOINTS
+        if self.scene_type == "isolated":
+            return
+        if self.use_limb_pose_to_initialize:
+            torso = multiply_poses(self.limb_base_pose, self.torso_to_limb.invert())
+            object.__setattr__(self, "torso_base_pose", torso)
+        else:
+            limb = multiply_poses(self.torso_base_pose, self.torso_to_limb)
+            object.__setattr__(self, "limb_base_pose", limb)
+
+    def get_torso_to_limb(self, limb_name: str) -> Pose:
+        """The transform from the torso to any limb, active or not."""
+        return {
+            "human-left-arm": self.torso_to_left_arm,
+            "human-right-arm": self.torso_to_right_arm,
+            "human-left-leg": self.torso_to_left_leg,
+            "human-right-leg": self.torso_to_right_leg,
+        }[limb_name]
+
+    @property
+    def torso_to_limb(self) -> Pose:
+        """The transform from the torso to the limb being repositioned."""
+        return self.get_torso_to_limb(self.limb_name)
+
+    @property
+    def grasp_transform(self) -> Pose:
+        """The transform from the limb's grasp frame to the robot's end effector."""
+        return ARM_GRASP_TRANSFORM if "arm" in self.limb_name else LEG_GRASP_TRANSFORM
+
+    def get_limb_init_joint_positions(self, limb_name: str) -> tuple[float, ...]:
+        """The initial joint positions of any limb, active or not."""
+        if limb_name == self.limb_name:
+            return self.limb_init_joint_positions
+        return {
+            "human-left-arm": self.left_arm_init_joint_positions,
+            "human-right-arm": self.right_arm_init_joint_positions,
+            "human-left-leg": self.left_leg_init_joint_positions,
+            "human-right-leg": self.right_leg_init_joint_positions,
+        }[limb_name]
+
+    def get_limb_base_pose(self, limb_name: str) -> Pose:
+        """The base pose of any limb, active or not."""
+        if self.scene_type == "isolated":
+            assert limb_name == self.limb_name
+            return self.limb_base_pose
+        return multiply_poses(self.torso_base_pose, self.get_torso_to_limb(limb_name))
+
+
+class LimbRepositioningScene(abc.ABC):
+    """Everything in the world except the robot."""
+
+    def __init__(
+        self, scene_config: LimbRepositioningSceneConfig, physics_client_id: int
+    ) -> None:
+        self.scene_config = scene_config
+        self.physics_client_id = physics_client_id
+        self._create_bodies()
+        self.passive_limb = self._create_passive_limb()
+        if scene_config.show_goal:
+            self._visualize_goal()
+
+    @property
+    def grasp_transform(self) -> Pose:
+        """The transform from the limb's grasp frame to the robot's end effector."""
+        return self.scene_config.grasp_transform
+
+    @property
+    def furniture_id(self) -> int | None:
+        """The body the human is sitting or lying on, if the scene has one."""
+        return None
+
+    @abc.abstractmethod
+    def _create_bodies(self) -> None:
+        """Create everything except the passive limb."""
+
+    @abc.abstractmethod
+    def _create_passive_limb(self) -> HumanLimbPyBulletRobot:
+        """Create (or look up) the limb that the robot repositions."""
+
+    @abc.abstractmethod
+    def get_scene_collision_ids(self) -> list[int]:
+        """The bodies that the robot and limb should avoid."""
+
+    def get_limb_obstacle_ids(self) -> list[int]:
+        """The bodies the repositioned limb should not be driven into."""
+        return self.get_scene_collision_ids()
+
+    def _create_limb(
+        self, limb_name: str, joint_positions: tuple[float, ...] | None = None
+    ) -> HumanLimbPyBulletRobot:
+        config = self.scene_config
+        if joint_positions is None:
+            joint_positions = config.get_limb_init_joint_positions(limb_name)
+        return create_human_limb(
+            limb_name,
+            config.get_limb_base_pose(limb_name),
+            list(joint_positions),
+            config.limb_joint_limits_model_name,
+            config.limb_muscle_tone_model_name,
+            self.physics_client_id,
+        )
+
+    def _visualize_goal(self) -> None:
+        """Show a translucent copy of the limb in its goal configuration."""
+        config = self.scene_config
+        goal_limb = self._create_limb(
+            config.limb_name, config.limb_goal_joint_positions
+        )
+        num_joints = p.getNumJoints(
+            goal_limb.robot_id, physicsClientId=self.physics_client_id
+        )
+        for joint in range(num_joints):
+            p.changeVisualShape(
+                goal_limb.robot_id,
+                joint,
+                rgbaColor=list(config.goal_rgba),
+                physicsClientId=self.physics_client_id,
+            )
+            p.setCollisionFilterGroupMask(
+                goal_limb.robot_id,
+                joint,
+                0,
+                0,
+                physicsClientId=self.physics_client_id,
+            )
+        self.goal_limb = goal_limb
+
+
+class IsolatedLimbScene(LimbRepositioningScene):
+    """A single limb floating in an empty world."""
+
+    def _create_bodies(self) -> None:
+        pass
+
+    def _create_passive_limb(self) -> HumanLimbPyBulletRobot:
+        return self._create_limb(self.scene_config.limb_name)
+
+    def get_scene_collision_ids(self) -> list[int]:
+        return []
+
+
+class HumanScene(LimbRepositioningScene):
+    """A whole human: a static torso and head, plus four limbs."""
+
+    def _create_bodies(self) -> None:
+        config = self.scene_config
+        self.torso_id = p.loadURDF(
+            str(ASSETS_DIR / "human" / "torso_and_head.urdf"),
+            useFixedBase=True,
+            physicsClientId=self.physics_client_id,
+        )
+        set_pose(self.torso_id, config.torso_base_pose, self.physics_client_id)
+
+        self.limbs: dict[str, HumanLimbPyBulletRobot] = {
+            limb_name: self._create_limb(limb_name) for limb_name in ALL_LIMB_NAMES
+        }
+
+        # Only the limb being repositioned participates in collision checking.
+        for limb_name, limb in self.limbs.items():
+            if limb_name == config.limb_name:
+                continue
+            num_joints = p.getNumJoints(
+                limb.robot_id, physicsClientId=self.physics_client_id
+            )
+            for joint in range(num_joints):
+                p.setCollisionFilterGroupMask(
+                    limb.robot_id,
+                    joint,
+                    0,
+                    0,
+                    physicsClientId=self.physics_client_id,
+                )
+
+    def _create_passive_limb(self) -> HumanLimbPyBulletRobot:
+        return self.limbs[self.scene_config.limb_name]
+
+    def get_scene_collision_ids(self) -> list[int]:
+        return []
+
+    def get_limb_obstacle_ids(self) -> list[int]:
+        others = [
+            limb.robot_id
+            for name, limb in self.limbs.items()
+            if name != self.scene_config.limb_name
+        ]
+        return [self.torso_id] + others + super().get_limb_obstacle_ids()
+
+
+class RoomScene(HumanScene):
+    """A human in a room, with a textured floor and three walls."""
+
+    def _create_bodies(self) -> None:
+        super()._create_bodies()
+        config = self.scene_config
+
+        self.floor_id = p.loadURDF(
+            str(ASSETS_DIR / "floor" / "floor.urdf"),
+            config.floor_position,
+            useFixedBase=True,
+            physicsClientId=self.physics_client_id,
+        )
+        floor_texture_id = p.loadTexture(
+            str(ASSETS_DIR / "floor" / "floor_texture.jpg"), self.physics_client_id
+        )
+        p.changeVisualShape(
+            self.floor_id,
+            -1,
+            textureUniqueId=floor_texture_id,
+            physicsClientId=self.physics_client_id,
+        )
+
+        self.wall_ids = [
+            create_pybullet_block(
+                (1.0, 1.0, 1.0, 1.0),
+                config.wall_half_extents,
+                self.physics_client_id,
+            )
+            for _ in config.wall_poses
+        ]
+        wall_texture_id = p.loadTexture(
+            str(ASSETS_DIR / "light_blue_wall_texture.jpg"), self.physics_client_id
+        )
+        for wall_id, pose in zip(self.wall_ids, config.wall_poses, strict=True):
+            p.changeVisualShape(
+                wall_id,
+                -1,
+                textureUniqueId=wall_texture_id,
+                physicsClientId=self.physics_client_id,
+            )
+            set_pose(wall_id, pose, self.physics_client_id)
+
+        self._furniture_id = self._create_furniture()
+
+    @property
+    def furniture_id(self) -> int | None:
+        return self._furniture_id
+
+    @abc.abstractmethod
+    def _create_furniture(self) -> int:
+        """Create the thing the human is sitting or lying on."""
+
+    def _load_furniture(self, urdf_path: Path, pose: Pose) -> int:
+        body_id = p.loadURDF(
+            str(urdf_path),
+            useFixedBase=True,
+            physicsClientId=self.physics_client_id,
+        )
+        set_pose(body_id, pose, self.physics_client_id)
+        return body_id
+
+    def get_scene_collision_ids(self) -> list[int]:
+        return [self._furniture_id] + super().get_scene_collision_ids()
+
+
+class WheelchairScene(RoomScene):
+    """A human seated in a wheelchair."""
+
+    def _create_furniture(self) -> int:
+        return self._load_furniture(
+            ASSETS_DIR / "wheelchair" / "wheelchair.urdf",
+            self.scene_config.wheelchair_pose,
+        )
+
+
+class BedScene(RoomScene):
+    """A human lying on a hospital bed."""
+
+    def _create_furniture(self) -> int:
+        return self._load_furniture(
+            ASSETS_DIR / "hospital_bed" / "hospital_bed.urdf",
+            self.scene_config.bed_pose,
+        )
+
+
+SCENE_TYPE_TO_CLS: dict[str, type[LimbRepositioningScene]] = {
+    "isolated": IsolatedLimbScene,
+    "human": HumanScene,
+    "wheelchair": WheelchairScene,
+    "bed": BedScene,
+}
+ALL_SCENE_TYPES = tuple(SCENE_TYPE_TO_CLS)
+
+
+def create_scene(
+    scene_config: LimbRepositioningSceneConfig, physics_client_id: int
+) -> LimbRepositioningScene:
+    """Create a scene from its config."""
+    return SCENE_TYPE_TO_CLS[scene_config.scene_type](scene_config, physics_client_id)

--- a/tests/envs/dynamic3d/test_limb_scenes.py
+++ b/tests/envs/dynamic3d/test_limb_scenes.py
@@ -1,0 +1,222 @@
+"""Tests for limb_scenes.py."""
+
+import inspect
+
+import numpy as np
+import pybullet as p
+import pytest
+from pybullet_helpers.geometry import Pose, multiply_poses
+
+from kinder.envs.dynamic3d.limb_scenes import (
+    ALL_SCENE_TYPES,
+    ARM_GRASP_TRANSFORM,
+    LEG_GRASP_TRANSFORM,
+    BedScene,
+    HumanScene,
+    IsolatedLimbScene,
+    LimbRepositioningSceneConfig,
+    RoomScene,
+    WheelchairScene,
+    create_scene,
+)
+from kinder.envs.dynamic3d.limb_utils import NUM_LIMB_JOINTS
+from kinder.envs.dynamic3d.limbs import ALL_LIMB_NAMES, HumanLimbPyBulletRobot
+
+INIT_JOINTS = (0.0, -0.1, 0.1, 0.5, 0.0, 0.0)
+GOAL_JOINTS = (0.0, 0.2, 0.1, 1.0, 0.0, 0.0)
+
+
+@pytest.fixture(name="physics_client_id")
+def _physics_client_id():
+    """A headless PyBullet connection, torn down after each test."""
+    client_id = p.connect(p.DIRECT)
+    yield client_id
+    p.disconnect(physicsClientId=client_id)
+
+
+def _make_config(scene_type="isolated", limb_name="human-left-arm", **kwargs):
+    """A minimal valid scene config."""
+    kwargs.setdefault("limb_init_joint_positions", INIT_JOINTS)
+    kwargs.setdefault("limb_goal_joint_positions", GOAL_JOINTS)
+    return LimbRepositioningSceneConfig(
+        scene_type=scene_type,
+        limb_name=limb_name,
+        **kwargs,
+    )
+
+
+def test_all_scene_types_are_registered():
+    """There are four kinds of scene, in increasing order of clutter."""
+    assert set(ALL_SCENE_TYPES) == {"isolated", "human", "wheelchair", "bed"}
+
+
+def test_config_rejects_unknown_scene_type():
+    """An unknown scene type is caught at construction."""
+    with pytest.raises(AssertionError):
+        _make_config(scene_type="spaceship")
+
+
+def test_config_rejects_unknown_limb_name():
+    """An unknown limb name is caught at construction."""
+    with pytest.raises(AssertionError):
+        _make_config(limb_name="human-third-arm")
+
+
+@pytest.mark.parametrize(
+    "field", ["limb_init_joint_positions", "limb_goal_joint_positions"]
+)
+def test_config_rejects_wrong_joint_count(field):
+    """Both the initial and goal configurations need one entry per joint."""
+    with pytest.raises(AssertionError):
+        _make_config(**{field: (0.0, 0.0)})
+
+
+def test_isolated_scene_keeps_the_given_limb_base_pose():
+    """With no torso, the limb's base pose is used as given."""
+    limb_pose = Pose.from_rpy((1.0, 2.0, 3.0), (0.0, 0.0, 0.0))
+    config = _make_config(scene_type="isolated", limb_base_pose=limb_pose)
+    assert np.allclose(config.limb_base_pose.position, limb_pose.position)
+    assert np.allclose(
+        config.get_limb_base_pose(config.limb_name).position, (1.0, 2.0, 3.0)
+    )
+
+
+def test_limb_base_pose_is_derived_from_the_torso():
+    """By default the torso is placed and the limb follows from the attachment."""
+    torso = Pose.from_rpy((0.5, 0.0, 0.0), (0.0, 0.0, 0.0))
+    config = _make_config(
+        scene_type="human", limb_name="human-left-arm", torso_base_pose=torso
+    )
+    expected = multiply_poses(torso, config.torso_to_left_arm)
+    assert np.allclose(config.limb_base_pose.position, expected.position)
+
+
+def test_torso_pose_is_derived_from_the_limb_when_requested():
+    """use_limb_pose_to_initialize inverts the relationship."""
+    limb_pose = Pose.from_rpy((1.0, 1.0, 1.0), (0.0, 0.0, 0.0))
+    config = _make_config(
+        scene_type="human",
+        limb_name="human-left-arm",
+        limb_base_pose=limb_pose,
+        use_limb_pose_to_initialize=True,
+    )
+    assert np.allclose(config.limb_base_pose.position, limb_pose.position)
+    recovered = multiply_poses(config.torso_base_pose, config.torso_to_left_arm)
+    assert np.allclose(recovered.position, limb_pose.position, atol=1e-6)
+
+
+@pytest.mark.parametrize("limb_name", ALL_LIMB_NAMES)
+def test_grasp_transform_depends_on_arm_or_leg(limb_name):
+    """Arms and legs are approached from different directions."""
+    config = _make_config(limb_name=limb_name)
+    expected = ARM_GRASP_TRANSFORM if "arm" in limb_name else LEG_GRASP_TRANSFORM
+    assert np.allclose(config.grasp_transform.position, expected.position)
+    assert np.allclose(config.grasp_transform.orientation, expected.orientation)
+
+
+@pytest.mark.parametrize("limb_name", ALL_LIMB_NAMES)
+def test_torso_to_limb_is_defined_for_every_limb(limb_name):
+    """Each of the four limbs has an attachment point on the torso."""
+    config = _make_config(scene_type="human", limb_name=limb_name)
+    assert np.allclose(
+        config.torso_to_limb.position, config.get_torso_to_limb(limb_name).position
+    )
+
+
+def test_active_limb_uses_the_task_joint_positions():
+    """The limb being repositioned starts at the task's initial configuration."""
+    config = _make_config(scene_type="human", limb_name="human-left-arm")
+    assert config.get_limb_init_joint_positions("human-left-arm") == INIT_JOINTS
+
+
+def test_inactive_limbs_use_their_resting_joint_positions():
+    """The other limbs rest, independent of the task."""
+    resting = (0.1,) * NUM_LIMB_JOINTS
+    config = _make_config(
+        scene_type="human",
+        limb_name="human-left-arm",
+        right_arm_init_joint_positions=resting,
+    )
+    assert config.get_limb_init_joint_positions("human-right-arm") == resting
+
+
+@pytest.mark.parametrize(
+    "scene_type,expected_cls",
+    [
+        ("isolated", IsolatedLimbScene),
+        ("human", HumanScene),
+        ("wheelchair", WheelchairScene),
+        ("bed", BedScene),
+    ],
+)
+def test_create_scene_builds_the_right_class(
+    scene_type, expected_cls, physics_client_id
+):
+    """Every scene type builds and exposes a passive limb."""
+    config = _make_config(scene_type=scene_type)
+    scene = create_scene(config, physics_client_id)
+    assert isinstance(scene, expected_cls)
+    assert isinstance(scene.passive_limb, HumanLimbPyBulletRobot)
+    assert len(scene.passive_limb.arm_joints) == NUM_LIMB_JOINTS
+
+
+def test_isolated_scene_is_empty(physics_client_id):
+    """Nothing to collide with when the limb floats in an empty world."""
+    scene = create_scene(_make_config(scene_type="isolated"), physics_client_id)
+    assert scene.get_scene_collision_ids() == []
+    assert scene.get_limb_obstacle_ids() == []
+    assert scene.furniture_id is None
+
+
+def test_human_scene_has_four_limbs_and_a_torso(physics_client_id):
+    """The whole body is present, and the other limbs are obstacles."""
+    config = _make_config(scene_type="human", limb_name="human-left-arm")
+    scene = create_scene(config, physics_client_id)
+    assert isinstance(scene, HumanScene)
+    assert set(scene.limbs) == set(ALL_LIMB_NAMES)
+    assert scene.passive_limb is scene.limbs["human-left-arm"]
+    obstacles = scene.get_limb_obstacle_ids()
+    assert scene.torso_id in obstacles
+    # The three limbs that are not being repositioned.
+    assert len(obstacles) == 1 + len(ALL_LIMB_NAMES) - 1
+    assert scene.furniture_id is None
+
+
+@pytest.mark.parametrize("scene_type", ["wheelchair", "bed"])
+def test_room_scenes_have_furniture_and_walls(scene_type, physics_client_id):
+    """The furniture is a collision body and the room is built around it."""
+    scene = create_scene(_make_config(scene_type=scene_type), physics_client_id)
+    assert scene.furniture_id is not None
+    assert scene.furniture_id in scene.get_scene_collision_ids()
+    assert len(scene.wall_ids) == len(scene.scene_config.wall_poses)
+    assert scene.floor_id >= 0
+
+
+def test_goal_limb_is_shown_when_requested(physics_client_id):
+    """The translucent goal copy is created only when show_goal is set."""
+    scene = create_scene(
+        _make_config(scene_type="isolated", show_goal=True), physics_client_id
+    )
+    assert scene.goal_limb is not None
+    assert np.allclose(scene.goal_limb.get_joint_positions(), GOAL_JOINTS, atol=1e-6)
+
+
+def test_goal_limb_is_omitted_when_not_requested(physics_client_id):
+    """No goal visualization means no extra body in the world."""
+    scene = create_scene(
+        _make_config(scene_type="isolated", show_goal=False), physics_client_id
+    )
+    assert not hasattr(scene, "goal_limb")
+
+
+def test_passive_limb_starts_at_the_initial_configuration(physics_client_id):
+    """The scene places the limb at the task's initial joint positions."""
+    scene = create_scene(_make_config(scene_type="isolated"), physics_client_id)
+    assert np.allclose(scene.passive_limb.get_joint_positions(), INIT_JOINTS, atol=1e-6)
+
+
+def test_room_scenes_share_a_public_base():
+    """RoomScene is the abstract base for the scenes with furniture."""
+    assert inspect.isabstract(RoomScene)
+    assert issubclass(WheelchairScene, RoomScene)
+    assert issubclass(BedScene, RoomScene)


### PR DESCRIPTION
The four scenes a limb can be repositioned in, in increasing order of clutter: isolated,
human, wheelchair, and bed.

`LimbRepositioningSceneConfig` derives the limb pose from the torso, or the torso pose
from the limb when `use_limb_pose_to_initialize` is set.

Tests: `tests/envs/kinematic3d/test_limb_scenes.py` (29 tests) covers the config
validation and both pose-derivation directions, the arm and leg grasp transforms, and
building all four scene types in PyBullet.
