### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/docs/maintaining.md
+++ b/docs/maintaining.md
@@ -8,7 +8,7 @@
 
 ## Dependencies from prpl-mono
 
-Kinder depends on four packages from the [prpl-mono](https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono) monorepo, all published to PyPI:
+Kinder depends on five packages from the [prpl-mono](https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono) monorepo, all published to PyPI:
 
 | PyPI name | Import name | prpl-mono directory | Used by |
 |-----------|-------------|---------------------|---------|
@@ -16,17 +16,39 @@ Kinder depends on four packages from the [prpl-mono](https://github.com/Princeto
 | `relational_structs` | `relational_structs` | `relational-structs/` | core |
 | `tomsgeoms2d` | `tomsgeoms2d` | `toms-geoms-2d/` | dynamic2d, kinematic2d |
 | `pybullet_helpers` | `pybullet_helpers` | `pybullet-helpers/` | kinematic3d |
+| `prpl_kinematics` | `prpl_kinematics` | `prpl-kinematics/` | kinematic3d_v2 |
+
+`prpl_kinematics` is an optional dependency, installed via the `prpl-kinematics` extra
+(`pip install "kindergarden[prpl-kinematics]"`) or `requirements/kinematic3d_v2.txt`. It
+overlaps heavily with `pybullet_helpers` and both are large, so a base install pulls in
+neither pair member beyond what the other environments need. The `develop` extra installs
+it so the kinematic3d_v2 environments are linted, type checked, and tested.
 
 ## Releasing a New Version
 
 ### 1. Release prpl-mono dependencies first (if changed)
 
-If you changed any of the four prpl-mono packages above, publish them before publishing kinder. The publish order matters because of inter-dependencies:
+If you changed any of the five prpl-mono packages above, publish them before publishing kinder. The publish order matters because of inter-dependencies:
 
 1. `prpl_utils` (no prpl-mono deps)
 2. `tomsgeoms2d` (no prpl-mono deps)
 3. `relational_structs` (depends on `prpl_utils`)
 4. `pybullet_helpers` (depends on `prpl_utils`)
+5. `prpl_kinematics` (depends on `prpl_utils`)
+
+To check whether a package has unpublished changes, compare its `version` in
+`pyproject.toml` against PyPI, and look for commits touching its directory since that
+version was set:
+
+```bash
+cd prpl-mono
+bump=$(git log -1 --format=%H -- <package-dir>/pyproject.toml)
+git log --oneline $bump..HEAD -- <package-dir>/
+```
+
+A matching version number does not by itself mean the published artifact is current: the
+version may have been bumped without a publish, or commits may have landed after it. When
+it matters, diff the published wheel against your working tree.
 
 For each package that changed:
 
@@ -64,7 +86,14 @@ gh release create v0.0.X --title "v0.0.X" --generate-notes
 
 ### Version numbering
 
-Use `0.0.x` for early development. Bump the patch version for each release.
+Bump the patch version (`0.2.1` → `0.2.2`) for fixes and additive changes. Bump the minor
+version (`0.2.x` → `0.3.0`) when an environment is removed or renamed, when a registration
+or state-space API changes, or when a new environment family arrives with its own extra.
+The major version stays at `0` for now.
+
+Keep the PyPI publish and the GitHub release together. If a publish happens without a tag,
+`--generate-notes` on the next release spans from the last tag and picks up the skipped
+commits, but the intermediate version has no reachable release notes.
 
 ## CI
 
@@ -82,5 +111,5 @@ uv pip install -e ".[develop]"
 If you're also developing the prpl-mono dependencies locally, install them in editable mode and they will take precedence over the PyPI versions:
 
 ```bash
-uv pip install -e ../prpl-mono/prpl-utils -e ../prpl-mono/relational-structs -e ../prpl-mono/toms-geoms-2d -e ../prpl-mono/pybullet-helpers
+uv pip install -e ../prpl-mono/prpl-utils -e ../prpl-mono/relational-structs -e ../prpl-mono/toms-geoms-2d -e ../prpl-mono/pybullet-helpers -e ../prpl-mono/prpl-kinematics
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kindergarden"
-version = "0.2.0"
+version = "0.2.1"
 description = "A robotics benchmark for physical reasoning."
 license = {text = "MIT"}
 readme = "README.md"


### PR DESCRIPTION
Bumps the version to 0.2.1 so the environments added since 0.2.0 become installable from PyPI.

## Why now

0.2.0 was published to PyPI on 2026-07-16 and 12 commits have landed since, including the `VegaMotion3D` environment and the `kinematic3d_v2` family (#140). None of that is reachable via `pip install kindergarden` today.

0.2.0 was also published without a git tag or GitHub release, so the release notes for v0.2.1 will span from v0.1.3 and cover the whole gap.

## Release checklist (docs/maintaining.md)

- **Step 1, prpl-mono dependencies:** no releases needed. All five match PyPI latest, and the published `prpl_kinematics` 0.0.1 wheel is byte-identical to prpl-mono HEAD across all 47 Python files.
- **Step 2, dependency pins:** unchanged, since no new dependency versions were published.
- **Checks:** `run_ci_checks.sh` green — 391 passed, 2387 skipped, mypy clean on 129 source files, notebook passes.

## No impact on existing users

`prpl_kinematics` is optional, and a plain `pip install kindergarden` is unaffected. Verified with a clean-venv install of the built wheel: `prpl_kinematics` is not pulled in, 97 environments register, and nothing errors. With the `prpl-kinematics` extra the count is 98, the difference being `VegaMotion3D` alone. `register_all_environments()` gates the family behind `_check_deps`, which catches `Exception` rather than only `ImportError`, and registration passes the entry point as a string so the module is never imported unless the environment is made.

Reaching `VegaMotion3D` requires `pip install "kindergarden[prpl-kinematics]"`.

## docs/maintaining.md

The doc had drifted from the code:

- The dependency table listed four prpl-mono packages; `prpl_kinematics` is a fifth. Added it, with a note that it is optional via the extra or `requirements/kinematic3d_v2.txt` and installed by `develop`.
- Added it to the publish order as step 5, since it depends on `prpl_utils`.
- Added a snippet for detecting unpublished prpl-mono changes, plus the caveat that a version matching PyPI does not mean the published artifact is current. `pybullet_helpers` is the live example: it reads 0.1.1 locally and 0.1.1 on PyPI, yet ten commits have landed since that version was set.
- Replaced the `0.0.x` version guidance with patch-vs-minor criteria, and noted that the PyPI publish and the GitHub release should stay together.
- Added `prpl-kinematics` to the editable-install line for local development.

## Noted, not fixed here

The CI `autoformat` job runs `run_autoformat.sh`, which rewrites files in place, and never checks for a resulting diff, so formatting violations cannot fail CI. Four files on `main` are currently unformatted. Their reformats were reverted from this branch to keep the release diff minimal.
