### PR TITLE
Resample constrained robot spawns in cluttered retrieval

### DIFF
--- a/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
+++ b/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
@@ -165,6 +165,7 @@ class ObjectCentricClutteredRetrieval2DEnv(
         self._num_obstructions = num_obstructions
 
     def _sample_initial_state(self) -> ObjectCentricState:
+        """Resample until the robot is in the largest collision-free component."""
         for _ in range(self.config.max_init_sampling_attempts):
             state = self._sample_initial_state_once()
             if self._initial_state_is_valid(state):

--- a/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
+++ b/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
@@ -191,8 +191,11 @@ class ObjectCentricClutteredRetrieval2DEnv(
                 if obj != region
             ]
         )
-        free = max(get_parts(world.difference(blocked)), key=lambda part: part.area)
-        return bool(free.covers(Point(state.get(robot, "x"), state.get(robot, "y"))))
+        robot_position = Point(state.get(robot, "x"), state.get(robot, "y"))
+        return any(
+            part.intersects(world.boundary) and part.covers(robot_position)
+            for part in get_parts(world.difference(blocked))
+        )
 
     def _sample_initial_state_once(self) -> ObjectCentricState:
         static_objects = set(self.initial_constant_state)

--- a/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
+++ b/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
@@ -191,11 +191,8 @@ class ObjectCentricClutteredRetrieval2DEnv(
                 if obj != region
             ]
         )
-        robot_position = Point(state.get(robot, "x"), state.get(robot, "y"))
-        return any(
-            part.intersects(world.boundary) and part.covers(robot_position)
-            for part in get_parts(world.difference(blocked))
-        )
+        free = max(get_parts(world.difference(blocked)), key=lambda part: part.area)
+        return bool(free.covers(Point(state.get(robot, "x"), state.get(robot, "y"))))
 
     def _sample_initial_state_once(self) -> ObjectCentricState:
         static_objects = set(self.initial_constant_state)

--- a/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
+++ b/src/kinder/envs/kinematic2d/clutteredretrieval2d.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import numpy as np
 from relational_structs import Object, ObjectCentricState, Type
 from relational_structs.utils import create_state_from_dict
+from shapely import Point, Polygon, box, get_parts, unary_union
 from tomsgeoms2d.utils import geom2ds_intersect
 
 from kinder.core import ConstantObjectKinDEREnv, FinalConfigMeta
@@ -164,6 +165,36 @@ class ObjectCentricClutteredRetrieval2DEnv(
         self._num_obstructions = num_obstructions
 
     def _sample_initial_state(self) -> ObjectCentricState:
+        for _ in range(self.config.max_init_sampling_attempts):
+            state = self._sample_initial_state_once()
+            if self._initial_state_is_valid(state):
+                return state
+        raise RuntimeError("Failed to sample initial state.")
+
+    def _initial_state_is_valid(self, state: ObjectCentricState) -> bool:
+        """Validity check on a sampled initial state."""
+        robot = state.get_objects(CRVRobotType)[0]
+        radius = state.get(robot, "base_radius")
+        region = state.get_objects(TargetRegionType)[0]
+        world = box(
+            self.config.world_min_x + radius,
+            self.config.world_min_y + radius,
+            self.config.world_max_x - radius,
+            self.config.world_max_y - radius,
+        )
+        blocked = unary_union(
+            [
+                Polygon(rectangle_object_to_geom(state, obj, {}).vertices).buffer(
+                    radius
+                )
+                for obj in state.get_objects(RectangleType)
+                if obj != region
+            ]
+        )
+        free = max(get_parts(world.difference(blocked)), key=lambda part: part.area)
+        return bool(free.covers(Point(state.get(robot, "x"), state.get(robot, "y"))))
+
+    def _sample_initial_state_once(self) -> ObjectCentricState:
         static_objects = set(self.initial_constant_state)
         robot_pose = sample_se2_pose(self.config.robot_init_pose_bounds, self.np_random)
         state = self._create_initial_state(robot_pose)

--- a/tests/envs/kinematic2d/test_clutteredretrieval2d.py
+++ b/tests/envs/kinematic2d/test_clutteredretrieval2d.py
@@ -92,28 +92,6 @@ def test_clutteredretrieval2d_free_space_check_flags_walled_in_robot():
     assert check(state)
 
 
-def test_clutteredretrieval2d_rejects_larger_enclosed_free_space():
-    """Tests that an enclosed component is rejected even when it is the largest."""
-    env = ObjectCentricClutteredRetrieval2DEnv(num_obstructions=0)
-    env.reset(seed=0)
-    # These bars enclose most of the world while leaving a smaller free-space
-    # component around the outside of the ring.
-    ring = [
-        (SE2Pose(0.25, 0.25, 0.0), (2.0, 0.05)),
-        (SE2Pose(0.25, 2.2, 0.0), (2.0, 0.05)),
-        (SE2Pose(0.25, 0.3, 0.0), (0.05, 1.9)),
-        (SE2Pose(2.2, 0.3, 0.0), (0.05, 1.9)),
-    ]
-    state = env._create_initial_state(  # pylint: disable=protected-access
-        SE2Pose(1.25, 1.25, 0.0),
-        target_pose=SE2Pose(1.8, 1.8, 0.0),
-        target_region_pose=SE2Pose(0.3, 0.3, 0.0),
-        obstructions=ring,
-    )
-    check = env._initial_state_is_valid  # pylint: disable=protected-access
-    assert not check(state)
-
-
 def test_clutteredretrieval2d_robot_spawns_in_main_free_space():
     """Tests that dense initial states never wall in the robot.
 

--- a/tests/envs/kinematic2d/test_clutteredretrieval2d.py
+++ b/tests/envs/kinematic2d/test_clutteredretrieval2d.py
@@ -11,6 +11,7 @@ from kinder.envs.kinematic2d.clutteredretrieval2d import (
     TargetRegionType,
 )
 from kinder.envs.kinematic2d.object_types import CRVRobotType
+from kinder.envs.kinematic2d.structs import SE2Pose
 from kinder.envs.utils import object_to_multibody2d, rectangle_object_to_geom
 from tests.conftest import MAKE_VIDEOS
 
@@ -61,6 +62,47 @@ def test_clutteredretrieval2d_target_starts_outside_region():
     target_block_geom = rectangle_object_to_geom(state, target_block, {})
     target_region_geom = rectangle_object_to_geom(state, target_region, {})
     assert not geom2ds_intersect(target_block_geom, target_region_geom)
+
+
+def test_clutteredretrieval2d_free_space_check_flags_walled_in_robot():
+    """Tests that the free-space check rejects a robot ringed by obstructions."""
+    env = ObjectCentricClutteredRetrieval2DEnv(num_obstructions=0)
+    env.reset(seed=0)
+    # Four bars forming a closed box around the robot at the world center.
+    ring = [
+        (SE2Pose(1.0, 1.0, 0.0), (0.5, 0.05)),
+        (SE2Pose(1.0, 1.45, 0.0), (0.5, 0.05)),
+        (SE2Pose(1.0, 1.05, 0.0), (0.05, 0.4)),
+        (SE2Pose(1.45, 1.05, 0.0), (0.05, 0.4)),
+    ]
+    state = env._create_initial_state(  # pylint: disable=protected-access
+        SE2Pose(1.25, 1.25, 0.0),
+        target_pose=SE2Pose(2.0, 2.0, 0.0),
+        target_region_pose=SE2Pose(0.3, 0.3, 0.0),
+        obstructions=ring,
+    )
+    check = env._initial_state_is_valid  # pylint: disable=protected-access
+    assert not check(state)
+    # The same layout without the ring leaves the robot in the main free space.
+    state = env._create_initial_state(  # pylint: disable=protected-access
+        SE2Pose(1.25, 1.25, 0.0),
+        target_pose=SE2Pose(2.0, 2.0, 0.0),
+        target_region_pose=SE2Pose(0.3, 0.3, 0.0),
+    )
+    assert check(state)
+
+
+def test_clutteredretrieval2d_robot_spawns_in_main_free_space():
+    """Tests that dense initial states never wall in the robot.
+
+    Both seeds draw a layout with the robot inside the obstruction cluster on the first
+    attempt, exercising the resampling loop.
+    """
+    env = ObjectCentricClutteredRetrieval2DEnv(num_obstructions=25)
+    check = env._initial_state_is_valid  # pylint: disable=protected-access
+    for seed in (48563862895646264, 1985872226597826804):
+        state, _ = env.reset(seed=seed)
+        assert check(state)
 
 
 def test_clutteredretrieval2d_target_region_does_not_overlap_robot():

--- a/tests/envs/kinematic2d/test_clutteredretrieval2d.py
+++ b/tests/envs/kinematic2d/test_clutteredretrieval2d.py
@@ -92,6 +92,28 @@ def test_clutteredretrieval2d_free_space_check_flags_walled_in_robot():
     assert check(state)
 
 
+def test_clutteredretrieval2d_rejects_larger_enclosed_free_space():
+    """Tests that an enclosed component is rejected even when it is the largest."""
+    env = ObjectCentricClutteredRetrieval2DEnv(num_obstructions=0)
+    env.reset(seed=0)
+    # These bars enclose most of the world while leaving a smaller free-space
+    # component around the outside of the ring.
+    ring = [
+        (SE2Pose(0.25, 0.25, 0.0), (2.0, 0.05)),
+        (SE2Pose(0.25, 2.2, 0.0), (2.0, 0.05)),
+        (SE2Pose(0.25, 0.3, 0.0), (0.05, 1.9)),
+        (SE2Pose(2.2, 0.3, 0.0), (0.05, 1.9)),
+    ]
+    state = env._create_initial_state(  # pylint: disable=protected-access
+        SE2Pose(1.25, 1.25, 0.0),
+        target_pose=SE2Pose(1.8, 1.8, 0.0),
+        target_region_pose=SE2Pose(0.3, 0.3, 0.0),
+        obstructions=ring,
+    )
+    check = env._initial_state_is_valid  # pylint: disable=protected-access
+    assert not check(state)
+
+
 def test_clutteredretrieval2d_robot_spawns_in_main_free_space():
     """Tests that dense initial states never wall in the robot.
 


### PR DESCRIPTION
## Summary

- resample cluttered retrieval initial states until the robot is in the largest collision-free component
- account for the robot base radius when computing free space
- add regression coverage for explicitly enclosed and dense sampled scenes

## Motivation

Collision-free sampling can place the robot in a small isolated pocket formed by the obstructions. The robot then starts severely constrained even though no individual object overlaps it.

![Example of an enclosed robot spawn](https://raw.githubusercontent.com/merlerm/kindergarden/pr-149-assets/media/clutteredretrieval2d-enclosed-spawn.gif)

The new reset-time geometry check rejects these small disconnected components without running an explicit planner or exposing a strategy-specific solvability check. It intentionally uses the largest free-space component regardless of whether that component touches the world boundary.

## Validation

- `uv run --extra develop python -m pytest -q tests/envs/kinematic2d/test_clutteredretrieval2d.py`
- 7 passed
