### PR TITLE
Implement the environment contract in the limb base class

### DIFF
--- a/src/kinder/envs/dynamic3d/base_limbrepositioning3d.py
+++ b/src/kinder/envs/dynamic3d/base_limbrepositioning3d.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, Generic, TypeVar
 
 import gymnasium
 import numpy as np
@@ -118,13 +118,12 @@ class Limb3DEnvConfig(KinDEREnvConfig):
         }
 
 
-_ObsType = TypeVar("_ObsType", bound=LimbRepositioning3DObjectCentricState)
 _ConfigType = TypeVar("_ConfigType", bound=Limb3DEnvConfig)
 
 
 class ObjectCentricLimb3DRobotEnv(
-    ObjectCentricKinDEREnv[_ObsType, Array, _ConfigType],
-    Generic[_ObsType, _ConfigType],
+    ObjectCentricKinDEREnv[LimbRepositioning3DObjectCentricState, Array, _ConfigType],
+    Generic[_ConfigType],
 ):
     """Base class for torque-controlled PyBullet environments.
 
@@ -358,7 +357,7 @@ class ObjectCentricLimb3DRobotEnv(
             return feats
         raise ValueError(f"Unknown object: {object_name}")
 
-    def _get_obs(self) -> _ObsType:
+    def _get_obs(self) -> LimbRepositioning3DObjectCentricState:
         state = create_state_from_dict(
             {
                 Object(name, object_type): self._get_object_features(name)
@@ -368,9 +367,9 @@ class ObjectCentricLimb3DRobotEnv(
             state_cls=LimbRepositioning3DObjectCentricState,
         )
         assert isinstance(state, LimbRepositioning3DObjectCentricState)
-        return cast(_ObsType, state)
+        return state
 
-    def _set_state(self, state: _ObsType) -> None:
+    def _set_state(self, state: LimbRepositioning3DObjectCentricState) -> None:
         """Restore positions and velocities, then rebuild the weld.
 
         Velocities are part of the state because the dynamics depend on them, so
@@ -387,7 +386,7 @@ class ObjectCentricLimb3DRobotEnv(
         )
         self._reweld_limb()
 
-    def _get_state(self) -> _ObsType:
+    def _get_state(self) -> LimbRepositioning3DObjectCentricState:
         return self._get_obs()
 
     def _get_reward(self) -> float:
@@ -398,7 +397,9 @@ class ObjectCentricLimb3DRobotEnv(
         """Torque applied to the limb on top of its muscle tone, e.g. a spasm."""
         return None
 
-    def step(self, action: Array) -> tuple[_ObsType, float, bool, bool, dict]:
+    def step(
+        self, action: Array
+    ) -> tuple[LimbRepositioning3DObjectCentricState, float, bool, bool, dict]:
         torque = np.clip(
             action, self.torque_action_space.low, self.torque_action_space.high
         )
@@ -420,7 +421,7 @@ class ObjectCentricLimb3DRobotEnv(
 
     def reset(
         self, *, seed: int | None = None, options: dict | None = None
-    ) -> tuple[_ObsType, dict]:
+    ) -> tuple[LimbRepositioning3DObjectCentricState, dict]:
         gymnasium.Env.reset(self, seed=seed)
         if options is not None and "init_state" in options:
             self._set_state(options["init_state"])

--- a/src/kinder/envs/dynamic3d/base_limbrepositioning3d.py
+++ b/src/kinder/envs/dynamic3d/base_limbrepositioning3d.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, cast
 
 import gymnasium
 import numpy as np
@@ -24,11 +24,14 @@ from pybullet_helpers.inverse_kinematics import (
 )
 from pybullet_helpers.joint import JointPositions, JointVelocities
 from pybullet_helpers.robots import create_pybullet_mobile_robot
-from relational_structs import Array, ObjectCentricStateSpace, Type
+from relational_structs import Array, Object, ObjectCentricStateSpace, Type
+from relational_structs.utils import create_state_from_dict
 
 from kinder.core import KinDEREnvConfig, ObjectCentricKinDEREnv
 from kinder.envs.dynamic3d.limb_object_types import (
     Limb3DEnvTypeFeatures,
+    Limb3DLimbType,
+    Limb3DRobotType,
 )
 from kinder.envs.dynamic3d.limb_scenes import (
     LimbRepositioningScene,
@@ -318,10 +321,6 @@ class ObjectCentricLimb3DRobotEnv(
         return Limb3DEnvTypeFeatures
 
     @abc.abstractmethod
-    def _get_obs(self) -> _ObsType:
-        """Get the current observation."""
-
-    @abc.abstractmethod
     def goal_reached(self) -> bool:
         """Check if the goal is currently reached."""
 
@@ -329,12 +328,84 @@ class ObjectCentricLimb3DRobotEnv(
     def _reset_bodies(self) -> None:
         """Reset the robot and the limb to their initial positions and velocities."""
 
-    @abc.abstractmethod
+    @property
+    def _object_names(self) -> list[tuple[str, Type]]:
+        """The objects that appear in the observation."""
+        return [("robot", Limb3DRobotType), ("limb", Limb3DLimbType)]
+
+    def _get_object_features(self, object_name: str) -> dict[str, float]:
+        """The observed features of a single object."""
+        if object_name == "robot":
+            base_pose = self.robot.get_base()
+            feats = {
+                "pos_base_x": base_pose.x,
+                "pos_base_y": base_pose.y,
+                "pos_base_rot": base_pose.rot,
+            }
+            for i, value in enumerate(self._get_robot_joint_positions()):
+                feats[f"joint_{i + 1}"] = value
+            for i, value in enumerate(self._get_robot_joint_velocities()):
+                feats[f"joint_vel_{i + 1}"] = value
+            return feats
+        if object_name == "limb":
+            feats = {}
+            for i, value in enumerate(self.limb.get_joint_positions()):
+                feats[f"joint_{i + 1}"] = value
+            for i, value in enumerate(self.limb.get_joint_velocities()):
+                feats[f"joint_vel_{i + 1}"] = value
+            for i, value in enumerate(self.config.scene.limb_goal_joint_positions):
+                feats[f"goal_joint_{i + 1}"] = value
+            return feats
+        raise ValueError(f"Unknown object: {object_name}")
+
+    def _get_obs(self) -> _ObsType:
+        state = create_state_from_dict(
+            {
+                Object(name, object_type): self._get_object_features(name)
+                for name, object_type in self._object_names
+            },
+            Limb3DEnvTypeFeatures,
+            state_cls=LimbRepositioning3DObjectCentricState,
+        )
+        assert isinstance(state, LimbRepositioning3DObjectCentricState)
+        return cast(_ObsType, state)
+
     def _set_state(self, state: _ObsType) -> None:
-        """Set the state of the environment to the given one."""
+        """Restore positions and velocities, then rebuild the weld.
+
+        Velocities are part of the state because the dynamics depend on them, so
+        get_transition() would otherwise erase the system's momentum.
+        """
+        self.robot.arm.set_joints(
+            extend_joints_to_include_fingers(state.robot_joint_positions),
+            joint_velocities=extend_joints_to_include_fingers(
+                state.robot_joint_velocities
+            ),
+        )
+        self.limb.set_joints(
+            state.limb_joint_positions, joint_velocities=state.limb_joint_velocities
+        )
+        self._reweld_limb()
 
     def _get_state(self) -> _ObsType:
         return self._get_obs()
+
+    def _get_reward(self) -> float:
+        """One unit of cost per step, unless a subclass shapes the reward."""
+        return -1.0
+
+    def _get_extra_limb_torque(self) -> JointTorques | None:
+        """Torque applied to the limb on top of its muscle tone, e.g. a spasm."""
+        return None
+
+    def step(self, action: Array) -> tuple[_ObsType, float, bool, bool, dict]:
+        torque = np.clip(
+            action, self.torque_action_space.low, self.torque_action_space.high
+        )
+        self._apply_torques(list(torque), self._get_extra_limb_torque())
+        obs = self._get_obs()
+        info = {"limb_distance_to_goal": obs.limb_distance_to_goal}
+        return obs, self._get_reward(), self.goal_reached(), False, info
 
     def _create_observation_space(self, config: _ConfigType) -> ObjectCentricStateSpace:
         del config

--- a/tests/envs/dynamic3d/test_base_limbrepositioning3d.py
+++ b/tests/envs/dynamic3d/test_base_limbrepositioning3d.py
@@ -31,9 +31,7 @@ ROBOT_BASE_POSE = SE2Pose(0.3566, 0.4849, -0.6971)
 ROBOT_BASE_Z = -0.329
 
 
-class _MinimalLimb3DEnv(
-    ObjectCentricLimb3DRobotEnv[LimbRepositioning3DObjectCentricState, Limb3DEnvConfig]
-):
+class _MinimalLimb3DEnv(ObjectCentricLimb3DRobotEnv[Limb3DEnvConfig]):
     """The smallest concrete environment the base class admits."""
 
     def _create_constant_initial_state(self):

--- a/tests/envs/dynamic3d/test_base_limbrepositioning3d.py
+++ b/tests/envs/dynamic3d/test_base_limbrepositioning3d.py
@@ -8,18 +8,11 @@ import numpy as np
 import pybullet as p
 import pytest
 from pybullet_helpers.geometry import Pose, SE2Pose
-from relational_structs import Object
 from relational_structs.spaces import ObjectCentricStateSpace
-from relational_structs.utils import create_state_from_dict
 
 from kinder.envs.dynamic3d.base_limbrepositioning3d import (
     Limb3DEnvConfig,
     ObjectCentricLimb3DRobotEnv,
-)
-from kinder.envs.dynamic3d.limb_object_types import (
-    Limb3DEnvTypeFeatures,
-    Limb3DLimbType,
-    Limb3DRobotType,
 )
 from kinder.envs.dynamic3d.limb_scenes import LimbRepositioningSceneConfig
 from kinder.envs.dynamic3d.limb_utils import (
@@ -43,35 +36,6 @@ class _MinimalLimb3DEnv(
 ):
     """The smallest concrete environment the base class admits."""
 
-    def _get_obs(self) -> LimbRepositioning3DObjectCentricState:
-        base_pose = self.robot.get_base()
-        robot_feats = {
-            "pos_base_x": base_pose.x,
-            "pos_base_y": base_pose.y,
-            "pos_base_rot": base_pose.rot,
-        }
-        for i, value in enumerate(self._get_robot_joint_positions()):
-            robot_feats[f"joint_{i + 1}"] = value
-        for i, value in enumerate(self._get_robot_joint_velocities()):
-            robot_feats[f"joint_vel_{i + 1}"] = value
-        limb_feats = {}
-        for i, value in enumerate(self.limb.get_joint_positions()):
-            limb_feats[f"joint_{i + 1}"] = value
-        for i, value in enumerate(self.limb.get_joint_velocities()):
-            limb_feats[f"joint_vel_{i + 1}"] = value
-        for i, value in enumerate(self.config.scene.limb_goal_joint_positions):
-            limb_feats[f"goal_joint_{i + 1}"] = value
-        state = create_state_from_dict(
-            {
-                Object("robot", Limb3DRobotType): robot_feats,
-                Object("limb", Limb3DLimbType): limb_feats,
-            },
-            Limb3DEnvTypeFeatures,
-            state_cls=LimbRepositioning3DObjectCentricState,
-        )
-        assert isinstance(state, LimbRepositioning3DObjectCentricState)
-        return state
-
     def _create_constant_initial_state(self):
         return self._get_obs()
 
@@ -80,21 +44,14 @@ class _MinimalLimb3DEnv(
 
     def _reset_bodies(self) -> None:
         self.robot.arm.set_joints(
-            extend_joints_to_include_fingers(list(self._initial_robot_joints))
+            extend_joints_to_include_fingers(list(self._initial_robot_joints)),
+            joint_velocities=[0.0] * len(self.robot.arm.arm_joints),
         )
-        self.limb.set_joints(list(self.config.scene.limb_init_joint_positions))
+        self.limb.set_joints(
+            list(self.config.scene.limb_init_joint_positions),
+            joint_velocities=[0.0] * NUM_LIMB_JOINTS,
+        )
         self._regrasp_limb()
-
-    def _set_state(self, state) -> None:
-        self.robot.arm.set_joints(
-            extend_joints_to_include_fingers(list(state.robot_joint_positions))
-        )
-        self.limb.set_joints(list(state.limb_joint_positions))
-        self._reweld_limb()
-
-    def step(self, action):
-        self._apply_torques(list(action))
-        return self._get_obs(), -1.0, self.goal_reached(), False, {}
 
 
 def _make_config(**kwargs) -> Limb3DEnvConfig:
@@ -231,6 +188,28 @@ def test_render_returns_an_rgb_image(env):
         3,
     )
     assert img.dtype == np.uint8
+
+
+def test_get_transition_matches_stepping():
+    """A state plus an action must determine the next state, momentum included."""
+    env = _MinimalLimb3DEnv(config=_make_config(), allow_state_access=True)
+    try:
+        env.reset()
+        action = np.full(NUM_ROBOT_JOINTS, 0.5, dtype=np.float32)
+        # Build up real joint velocities, so that dropping them would show.
+        for _ in range(100):
+            env.step(action)
+        state = env.get_state()
+        stepped, _, _, _, _ = env.step(action)
+        predicted = env.get_next_state(state, action)
+        assert np.allclose(
+            predicted.limb_joint_positions, stepped.limb_joint_positions, atol=1e-3
+        )
+        assert np.allclose(
+            predicted.robot_joint_positions, stepped.robot_joint_positions, atol=1e-3
+        )
+    finally:
+        env.close()
 
 
 def test_a_coarse_dt_applies_torque_for_the_whole_interval():


### PR DESCRIPTION
## Motivation

Second of the three PRs that #145 was split into. Stacked on #145.

`ObjectCentricKinDEREnv` offers planners a "simulator as a model" interface:

```python
def get_transition(self, state, action):
    self._set_state(state)                              # put the sim into `state`
    obs, reward, terminated, _, _ = self.step(action)   # take one action
    return obs, reward, terminated
```

That is only truthful if the state carries everything the simulator needs and `_set_state` restores all of it. `Limb3DEnvTypeFeatures` gets this right — it carries `joint_vel_*` for both bodies, which is the correct call for a torque-controlled system — but the base class declared `_get_obs`, `_set_state` and `step` abstract, so the three methods that decide whether `get_transition` tells the truth lived outside the class that owns the simulator.

Two subclasses existed and one got it wrong. `LimbRepositioning3D` in #132 restores velocities correctly; the minimal subclass in #145's own tests dropped them, because `set_joints` defaults `joint_velocities` to zeros, and passed zero muscle tone. Nothing failed, because no test compared a predicted state against a stepped one.

## Changes

`_get_obs`, `_set_state` and `step` move into the base class. Subclasses keep only what genuinely differs between environments.

- `_set_state` restores joint positions **and velocities** for both bodies, then rebuilds the weld.
- `_get_obs` is built from `_object_names` and `_get_object_features`, both overridable, so a subclass with extra objects extends the list rather than reimplementing the state construction.
- `step` clips the action to the torque limits, applies it, and returns the observation, reward, termination and the distance-to-goal info dict.
- `_get_reward()` returns `-1.0` by default and `_get_extra_limb_torque()` returns `None`; subclasses override these instead of reimplementing `step`.
- `goal_reached` and `_reset_bodies` stay abstract.

The minimal test subclass drops from about fifty lines to sixteen.

## Notes

`_get_extra_limb_torque()` is the seam for the spasms in #132. That environment currently calls `_apply_torques` a second time to deliver a spasm, which advances the simulation by an extra `dt` with no robot torque and no muscle tone, making the control interval depend on a random draw. Overriding this hook instead folds the spasm into the same interval.

#132 should lose its `_set_state` entirely and shrink its `step` accordingly once this lands.


## Tests

`pytest tests/envs/dynamic3d/test_base_limbrepositioning3d.py` — 18 passed. `mypy` and `pylint` clean on both files.

`test_get_transition_matches_stepping` builds up real joint velocities over 100 steps, then checks that `get_next_state` agrees with actually stepping. This is the property the planning code depends on, and nothing checked it before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
