### PR TITLE
Add limb clearance and penetration measurement

### DIFF
--- a/src/kinder/envs/dynamic3d/base_limbrepositioning3d.py
+++ b/src/kinder/envs/dynamic3d/base_limbrepositioning3d.py
@@ -50,6 +50,9 @@ from kinder.envs.dynamic3d.limbs import HumanLimbPyBulletRobot
 from kinder.envs.kinematic3d.utils import extend_joints_to_include_fingers
 from kinder.envs.utils import RobotActionSpace
 
+# Clearances are only queried within this radius, and saturate at it.
+_CLEARANCE_QUERY_RADIUS = 0.5
+
 # Default scene config for the limb repositioning environment.
 _DEFAULT_SCENE = LimbRepositioningSceneConfig(
     scene_type="isolated",
@@ -129,6 +132,12 @@ class ObjectCentricLimb3DRobotEnv(
 
     A robot arm is rigidly attached to a passive human limb and repositions it by
     applying joint torques.
+
+    Collision response is disabled for the robot and for the limb, and gravity is off by
+    default, so nothing in the scene pushes back: the limb passes through the bed rather
+    than resting on it. Overlap is still measured, by distance queries that ignore the
+    collision filters, and reported as a cost by limb_penetration() and
+    get_collision_clearance().
     """
 
     def __init__(self, *args, use_gui: bool = False, **kwargs) -> None:
@@ -160,6 +169,9 @@ class ObjectCentricLimb3DRobotEnv(
         self.robot.arm.set_joints(
             extend_joints_to_include_fingers(list(self.config.robot_initial_joints))
         )
+
+        # Limbs already overlap the torso at rest, so record that as the baseline.
+        self._limb_rest_clearance: dict[int, float] = self._measure_limb_clearance()
 
         # Move the arm so that it grasps the limb, then weld the two together.
         self._move_robot_to_grasp_limb()
@@ -210,6 +222,49 @@ class ObjectCentricLimb3DRobotEnv(
                 self.robot.arm, robot_ee_pose, validate=False, best_effort=True
             )
             self.robot.arm.set_joints(joint_positions)
+
+    def _measure_limb_clearance(self) -> dict[int, float]:
+        """Distance from the limb to each obstacle in its current configuration."""
+        return {
+            body_id: self._closest_distance(self.limb.robot_id, body_id)
+            for body_id in self.scene.get_limb_obstacle_ids()
+        }
+
+    def _closest_distance(self, body_id: int, other_id: int) -> float:
+        """The closest distance between two bodies, saturating at the query radius."""
+        points = p.getClosestPoints(
+            body_id,
+            other_id,
+            _CLEARANCE_QUERY_RADIUS,
+            physicsClientId=self.physics_client_id,
+        )
+        return min((point[8] for point in points), default=_CLEARANCE_QUERY_RADIUS)
+
+    def limb_penetration(self) -> float:
+        """How far the limb intrudes past the overlap its model already has at rest."""
+        worst = 0.0
+        for body_id, distance in self._measure_limb_clearance().items():
+            worst = min(worst, distance - self._limb_rest_clearance.get(body_id, 0.0))
+        return worst
+
+    def get_collision_clearance(self) -> float:
+        """The smallest distance between the robot or limb and any static scene body.
+
+        Negative values mean penetration, and the result saturates at the query radius.
+        """
+        clearance = _CLEARANCE_QUERY_RADIUS
+        for body_id in self.scene.get_scene_collision_ids():
+            for other_id in (self.limb.robot_id, self.robot.arm.robot_id):
+                points = p.getClosestPoints(
+                    other_id,
+                    body_id,
+                    clearance,
+                    physicsClientId=self.physics_client_id,
+                )
+                for point in points:
+                    # The 9th element of a contact point is the contact distance.
+                    clearance = min(clearance, point[8])
+        return clearance
 
     def _reweld_limb(self) -> None:
         """Rebuild the weld from the current robot and limb poses."""

--- a/tests/envs/dynamic3d/test_base_limbrepositioning3d.py
+++ b/tests/envs/dynamic3d/test_base_limbrepositioning3d.py
@@ -11,6 +11,7 @@ from pybullet_helpers.geometry import Pose, SE2Pose
 from relational_structs.spaces import ObjectCentricStateSpace
 
 from kinder.envs.dynamic3d.base_limbrepositioning3d import (
+    _CLEARANCE_QUERY_RADIUS,
     Limb3DEnvConfig,
     ObjectCentricLimb3DRobotEnv,
 )
@@ -55,11 +56,12 @@ class _MinimalLimb3DEnv(ObjectCentricLimb3DRobotEnv[Limb3DEnvConfig]):
 def _make_config(**kwargs) -> Limb3DEnvConfig:
     """A config for an isolated right arm, settling briefly to keep tests quick."""
     scene = LimbRepositioningSceneConfig(
-        scene_type="isolated",
+        scene_type=kwargs.pop("scene_type", "isolated"),
         limb_name="human-right-arm",
         limb_init_joint_positions=LIMB_INIT,
         limb_goal_joint_positions=LIMB_GOAL,
         limb_base_pose=LIMB_BASE_POSE,
+        use_limb_pose_to_initialize=kwargs.pop("use_limb_pose_to_initialize", False),
     )
     return Limb3DEnvConfig(
         scene=scene,
@@ -176,6 +178,79 @@ def test_goal_joint_positions_come_from_the_config(env):
     assert np.allclose(obs.limb_goal_joint_positions, LIMB_GOAL)
 
 
+@pytest.fixture(scope="module", name="bed_env")
+def _bed_env():
+    """A bed scene, which has both limb obstacles and static bodies to measure."""
+    scene = LimbRepositioningSceneConfig(
+        scene_type="bed",
+        limb_name="human-right-arm",
+        limb_init_joint_positions=LIMB_INIT,
+        limb_goal_joint_positions=LIMB_GOAL,
+        torso_base_pose=Pose.from_rpy((-0.10, 0.0, 0.65), (-np.pi / 2, 0.0, 0.0)),
+        bed_pose=Pose.from_rpy((0.0, 0.0, 0.35), (0.0, 0.0, 0.0)),
+    )
+    environment = _MinimalLimb3DEnv(
+        config=Limb3DEnvConfig(
+            scene=scene,
+            robot_base_home_pose=SE2Pose(-0.8557, 0.0837, -0.9312),
+            robot_base_z=0.0,
+            num_settle_steps=100,
+        )
+    )
+    yield environment
+    environment.close()
+
+
+def test_clearances_are_finite_at_rest(bed_env):
+    """Both loops run here, and an obstacle out of range records the radius."""
+    assert bed_env.scene.get_limb_obstacle_ids()
+    assert bed_env.scene.get_scene_collision_ids()
+    bed_env.reset()
+    rest = bed_env._limb_rest_clearance  # pylint: disable=protected-access
+    assert all(np.isfinite(d) for d in rest.values())
+    assert max(rest.values()) <= _CLEARANCE_QUERY_RADIUS
+    # The arm already overlaps the torso at rest, which is why it is the baseline.
+    assert min(rest.values()) < 0.0
+    assert bed_env.limb_penetration() == pytest.approx(0.0)
+    assert bed_env.get_collision_clearance() <= _CLEARANCE_QUERY_RADIUS
+
+
+def test_driving_the_limb_into_the_torso_reports_penetration(bed_env):
+    """Penetration is measured even though collision response is disabled."""
+    bed_env.reset()
+    assert bed_env.limb_penetration() == pytest.approx(0.0)
+    # Swing the shoulder inward, which buries the arm in the torso.
+    bed_env.limb.set_joints([0.0, -1.4, 0.0, 0.0, 0.0, 0.0])
+    penetration = bed_env.limb_penetration()
+    assert -_CLEARANCE_QUERY_RADIUS < penetration < -0.1
+
+
+def test_closest_distance_saturates_for_an_out_of_range_body(bed_env):
+    """The -inf fix: an unreachable body reports the radius, so it can be subtracted."""
+    client = bed_env.physics_client_id
+    far_id = p.createMultiBody(
+        baseCollisionShapeIndex=p.createCollisionShape(
+            p.GEOM_BOX, halfExtents=[0.1] * 3, physicsClientId=client
+        ),
+        basePosition=[10.0, 10.0, 10.0],
+        physicsClientId=client,
+    )
+    try:
+        distance = bed_env._closest_distance(  # pylint: disable=protected-access
+            bed_env.limb.robot_id, far_id
+        )
+        assert distance == pytest.approx(_CLEARANCE_QUERY_RADIUS)
+    finally:
+        p.removeBody(far_id, physicsClientId=client)
+
+
+def test_isolated_scene_saturates_rather_than_returning_infinity(env):
+    """An empty world gives the limb nothing to intrude into."""
+    env.reset()
+    assert env.limb_penetration() == pytest.approx(0.0)
+    assert env.get_collision_clearance() == pytest.approx(_CLEARANCE_QUERY_RADIUS)
+
+
 def test_render_returns_an_rgb_image(env):
     """Rendering honours the configured image size."""
     env.reset()
@@ -230,20 +305,12 @@ def test_a_coarse_dt_applies_torque_for_the_whole_interval():
         coarse.close()
 
 
-def test_dt_must_be_a_whole_number_of_timesteps():
-    """A dt that is not a multiple of the timestep fails loudly rather than silently."""
-    with pytest.raises(AssertionError, match="PYBULLET_TIMESTEP"):
-        _make_config(dt=1.0 / 100.0)
-
-
-def test_render_fps_follows_dt():
-    """Videos play at real speed only if the frame rate matches the control rate."""
+def test_config_validates_dt_and_derives_the_frame_rate():
+    """A bad dt fails loudly, and videos play at real speed rather than four times."""
     assert _make_config().render_fps == 240
     assert _make_config(dt=1.0 / 60.0).render_fps == 60
-
-
-def test_default_config_builds_a_scene():
-    """The config is usable without being handed a scene."""
+    with pytest.raises(AssertionError, match="PYBULLET_TIMESTEP"):
+        _make_config(dt=1.0 / 100.0)
     assert Limb3DEnvConfig().scene.scene_type == "isolated"
 
 


### PR DESCRIPTION
## Motivation

Third of the three PRs that #145 was split into. Stacked on the environment contract PR.

Both clearance functions were previously covered only by `test_isolated_scene_has_no_penetration`, and the isolated scene returns no obstacle ids at all. The loops never executed, `worst` kept its initial `0.0`, and the assertion passed — replacing the whole function body with `return 0.0` would not have failed that test. #144 provides bed and wheelchair scenes, so the measurement can now be checked against obstacles that actually exist.


## Changes

- `_CLEARANCE_QUERY_RADIUS = 0.5` replaces the magic number, and `_closest_distance` saturates at the radius instead of returning infinity when nothing is within range.
- `get_collision_clearance` starts its shrinking query radius at the constant rather than at infinity, so the first `getClosestPoints` call is given a finite distance.

The bug: `_closest_distance` returned `inf` when nothing was within 0.5 m, so an obstacle beyond that radius at construction time left `_limb_rest_clearance[body_id] == inf` forever. When the limb later came within range, the subtraction gave `0.4 - inf == -inf`, reporting infinite penetration for a limb that had touched nothing. Verified against the old code:

```
new _closest_distance(far body): 0.5
old _closest_distance(far body): inf
penetration if that were the baseline -> 0.4 - inf = -inf
```

This is where it would have done real damage. `_sample_limb_init_joint_positions` in #132 accepts a perturbed configuration only if `limb_penetration() > -init_max_penetration`. With `-inf`, every draw is rejected and the sampler silently falls back to the nominal configuration, producing an identical initial state for every seed while the docstring promises the opposite.


## Tests

`pytest tests/envs/dynamic3d/test_base_limbrepositioning3d.py` — 20 passed. `mypy` and `pylint` clean on both files.

Four tests, against a bed scene that has both limb obstacles and static bodies:

- `test_clearances_are_finite_at_rest` — both loops have bodies to run over, the rest clearances are bounded by the query radius, and the baseline is negative because the arm already overlaps the torso.
- `test_driving_the_limb_into_the_torso_reports_penetration` — swinging the shoulder inward reports penetration, even though collision response is disabled.
- `test_closest_distance_saturates_for_an_out_of_range_body` — the regression test for the fix above.
- `test_isolated_scene_saturates_rather_than_returning_infinity` — the degenerate case with no obstacles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
