### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kindergarden"
-version = "0.2.1"
+version = "0.2.2"
 description = "A robotics benchmark for physical reasoning."
 license = {text = "MIT"}
 readme = "README.md"


### PR DESCRIPTION
Ships the VegaMotion3D target-generation change (#151): targets are now placed at the end effector of an arm configuration sampled near home, so they are reachable by construction, and the environment no longer uses inverse kinematics.

Note for downstream consumers: `target_reach_pose` was removed. kinder-baselines tracks its migration in [kinder-baselines#110](https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/issues/110); its `kindergarden>=` pin should move to 0.2.2 as part of that fix.

After this merges: publish to PyPI and create the `v0.2.2` GitHub release per `docs/maintaining.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
