### PR TITLE
kinder: schedule control within a substep loop

### DIFF
--- a/src/kinder/envs/dynamic3d/mujoco_utils.py
+++ b/src/kinder/envs/dynamic3d/mujoco_utils.py
@@ -26,6 +26,11 @@ from relational_structs import Array
 # to simulate for each step.
 SIMULATION_TIMESTEP = 0.0005  # (in seconds)
 
+# How long one row of a 2-D action is held for; see MujocoEnv.step. 1 kHz rather than
+# the 2 kHz physics rate because that is the real Kinova arm's low-level servo period
+# (jimmyyhwu/tidybot, robot/kinova.py: MoveJController.CYCLIC_STEP_SIZE)
+CONTROL_SCHEDULE_TIMESTEP = 0.001  # (in seconds)
+
 # Set macros needed for MuJoCo rendering
 _SYSTEM = platform.system()
 if _SYSTEM == "Windows":
@@ -138,16 +143,33 @@ class MujocoEnv(gymnasium.Env[MjObs, Array]):
         self.sim.data.mj_data.ctrl[:] = action
 
     def step(self, action: Array) -> tuple[MjObs, float, bool, bool, dict[str, Any]]:
+        """Advance one control period, from a single action or a control schedule.
+
+        A 1-D action is held for the whole period. A 2-D action is a schedule covering
+        the period exactly: it has one row per CONTROL_SCHEDULE_TIMESTEP.
+        """
         assert self.sim is not None, "Simulation must be initialized before stepping."
 
         assert self.timestep is not None, "Timestep must be initialized."
         self.timestep += 1
 
-        # Step the simulation with the same action until the control frequency
-        # is reached
         control_timestep = 1.0 / self.control_frequency
-        for _ in range(int(control_timestep / SIMULATION_TIMESTEP)):
-            self._update_ctrl(action)
+        num_sim_steps = int(control_timestep / SIMULATION_TIMESTEP)
+        ticks_per_row = int(round(CONTROL_SCHEDULE_TIMESTEP / SIMULATION_TIMESTEP))
+        schedule_rows = num_sim_steps // ticks_per_row
+        if action.ndim == 1:
+            # A read-only view, so the common path allocates nothing.
+            schedule = np.broadcast_to(action, (schedule_rows, *action.shape))
+        else:
+            schedule = action
+        assert len(schedule) == schedule_rows, (
+            f"a control schedule must have exactly {schedule_rows} rows at "
+            f"{self.control_frequency} Hz control and "
+            f"{CONTROL_SCHEDULE_TIMESTEP} s granularity, got {len(schedule)}"
+        )
+
+        for tick in range(num_sim_steps):
+            self._update_ctrl(schedule[tick // ticks_per_row])
             self.sim.forward()
             self.sim.step()
 

--- a/src/kinder/envs/dynamic3d/robots/tidybot_robot_env.py
+++ b/src/kinder/envs/dynamic3d/robots/tidybot_robot_env.py
@@ -371,7 +371,9 @@ class TidyBotRobotEnv(RobotEnv):
         - Gripper: Uses tendon control with force range [0, 255]
 
         Args:
-            action: Action array with shape (11,) or (18,):
+            action: Action array with shape (11,) or (18,). Or a 2-D array of
+                such rows covering the control period, which MujocoEnv.step
+                reads as a control schedule.
 
                 Position-only mode (11,) - backward compatible:
                     - [0:3]: Base position targets (x, y, theta) or deltas
@@ -387,6 +389,12 @@ class TidyBotRobotEnv(RobotEnv):
         Returns:
             Tuple of (observation, reward, terminated, truncated, info).
         """
+        if np.ndim(action) == 2:
+            return super().step(np.stack([self._action_to_ctrl(r) for r in action]))
+        return super().step(self._action_to_ctrl(action))
+
+    def _action_to_ctrl(self, action: Array) -> Array:
+        """Translate one action row into this robot's ctrl vector; a step() helper."""
         action = action.copy()
 
         # Parse action based on length for backward compatibility
@@ -430,7 +438,7 @@ class TidyBotRobotEnv(RobotEnv):
         # - Gripper: force command
         ctrl_action = np.concatenate([base_targets, arm_torques, [gripper_action]])
 
-        return super().step(ctrl_action)
+        return ctrl_action
 
     def reward(self, obs: MjObs) -> float:
         """Compute the reward from an observation.

--- a/tests/envs/dynamic3d/test_mujoco_utils.py
+++ b/tests/envs/dynamic3d/test_mujoco_utils.py
@@ -1,0 +1,125 @@
+"""Tests for MujocoEnv's per-substep control schedule."""
+
+import numpy as np
+import pytest
+from gymnasium.wrappers import RenderCollection
+
+from kinder.envs.dynamic3d.mujoco_utils import (
+    CONTROL_SCHEDULE_TIMESTEP,
+    SIMULATION_TIMESTEP,
+    MjObs,
+    MujocoEnv,
+)
+
+CONTROL_FREQUENCY = 10.0
+TICKS_PER_STEP = int((1.0 / CONTROL_FREQUENCY) / SIMULATION_TIMESTEP)
+TICKS_PER_ROW = int(round(CONTROL_SCHEDULE_TIMESTEP / SIMULATION_TIMESTEP))
+SCHEDULE_ROWS = TICKS_PER_STEP // TICKS_PER_ROW
+
+_XML = """
+<mujoco>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <body name="slider" pos="0 0 0">
+      <joint name="slide" type="slide" axis="1 0 0"/>
+      <geom type="box" size="0.1 0.1 0.1" mass="1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor joint="slide" name="push" gear="1"/>
+  </actuator>
+</mujoco>
+"""
+
+
+class _SliderEnv(MujocoEnv):
+    """A one-actuator MujocoEnv, so a schedule's effect is a single number."""
+
+    metadata = {"render_modes": ["rgb_array"], "render_fps": 10}
+
+    def __init__(self) -> None:
+        super().__init__(control_frequency=CONTROL_FREQUENCY)
+        self.render_mode = "rgb_array"
+
+    def reward(self, obs: MjObs) -> float:
+        return 0.0
+
+    def render(self):
+        return np.zeros((2, 2, 3), dtype=np.uint8)
+
+
+def make_env() -> _SliderEnv:
+    """A reset slider env, ready to step."""
+    env = _SliderEnv()
+    env.reset(options={"xml": _XML})
+    return env
+
+
+def replay_ticks(env: _SliderEnv, rows: np.ndarray) -> None:
+    """Drive the substep loop directly, from one explicit row per physics tick."""
+    assert env.timestep is not None
+    assert env.sim is not None
+    env.timestep += 1
+    for tick in range(TICKS_PER_STEP):
+        env._update_ctrl(rows[tick])  # pylint: disable=protected-access
+        env.sim.forward()
+        env.sim.step()
+
+
+def test_a_1d_action_is_held_for_every_tick_of_the_control_period():
+    """The 1-D path is a broadcast view, so it must match an explicit replay exactly."""
+    stepped, replayed = make_env(), make_env()
+    action = np.array([0.7])
+
+    stepped.step(action)
+    replay_ticks(replayed, np.repeat(action[None], TICKS_PER_STEP, axis=0))
+
+    assert np.array_equal(stepped.get_obs()["qpos"], replayed.get_obs()["qpos"])
+    assert np.array_equal(stepped.get_obs()["qvel"], replayed.get_obs()["qvel"])
+    assert stepped.timestep == replayed.timestep
+
+
+def test_a_schedule_holds_each_row_for_one_millisecond():
+    """Row j drives the j-th millisecond, checked against a tick-by-tick replay."""
+    scheduled, replayed, plain = make_env(), make_env(), make_env()
+    schedule = np.linspace(-1.0, 1.0, SCHEDULE_ROWS)[:, None]
+
+    scheduled.step(schedule)
+    replay_ticks(replayed, np.repeat(schedule, TICKS_PER_ROW, axis=0))
+    plain.step(schedule[0])
+
+    assert np.array_equal(scheduled.get_obs()["qpos"], replayed.get_obs()["qpos"])
+    assert np.array_equal(scheduled.get_obs()["qvel"], replayed.get_obs()["qvel"])
+    # Otherwise the two would agree by both ignoring every row after the first.
+    assert not np.allclose(scheduled.get_obs()["qpos"], plain.get_obs()["qpos"])
+
+
+@pytest.mark.parametrize("rows", [1, SCHEDULE_ROWS - 1, SCHEDULE_ROWS + 1])
+def test_a_schedule_shorter_or_longer_than_the_control_period_is_rejected(rows):
+    """A schedule covers the whole period, so a partial one is a caller bug.
+
+    Accepting one would mean inventing a rule for the ticks it does not cover, and
+    every such rule silently reinterprets the caller's timing.
+    """
+    env = make_env()
+    with pytest.raises(AssertionError, match="control schedule"):
+        env.step(np.zeros((rows, 1)))
+
+
+def test_a_schedule_survives_a_gymnasium_wrapper():
+    """Why the schedule rides on the action: a wrapper forwards only that.
+
+    RenderCollection takes one positional argument and passes it by value, so a
+    keyword or a second parameter would not reach the env it wraps -- and the
+    recording path wraps every env it films.
+    """
+    unwrapped, wrapped = make_env(), RenderCollection(make_env())
+    schedule = np.linspace(-1.0, 1.0, SCHEDULE_ROWS)[:, None]
+
+    unwrapped.step(schedule)
+    wrapped.step(schedule)
+
+    assert np.array_equal(
+        unwrapped.get_obs()["qpos"], wrapped.unwrapped.get_obs()["qpos"]
+    )
+    assert len(wrapped.render()) == 1


### PR DESCRIPTION
# Josh

In order to properly release a toss at the right time in Tossing3d, we need to have a high frequency controller, like we do on the real tidybot. This PR allows setting a sequence of actions rather than a single action to simulate that high frequency

# AI

## Summary

`MujocoEnv.step` held one action across every physics tick of a control period. At 10 Hz
control and a 0.5 ms physics timestep that is 200 ticks with a frozen command, so a
controller can only change what it asks for on a 100 ms boundary — long enough that a
gripper release, say, lands up to a tenth of a second late and by a different amount at
every commanded speed.

`step` now also accepts a **2-D action**: a schedule covering the control period exactly,
one row per `CONTROL_SCHEDULE_TIMESTEP`, with row `j` held for the `j`-th of them.
Nothing here knows what the rows mean — they are whatever this env's `_update_ctrl`
accepts — so every `Dynamic3D` env inherits it without any of them naming a gripper.

**Covering the period exactly is required, not merely allowed.** A shorter schedule would
need a rule for the ticks it omits, and any such rule reinterprets the caller's timing
without saying so. An earlier revision held the last row for the remainder, which made a
13-row and a 100-row schedule mean the same thing by accident; the consumer relied on
that, and now states its release index explicitly instead.

Three deliberate choices:

- **1 kHz, not the 2 kHz physics rate**, because that is the real Kinova arm's low-level
  servo period. In `jimmyyhwu/tidybot`'s `robot/kinova.py`,
  `MoveJController.CYCLIC_STEP_SIZE = 0.001` gates the send loop under
  `LOW_LEVEL_SERVOING` — one trajectory row per millisecond — and the same loop releases
  the gripper on `cyclic_count >= self.gripper_release_ms`. So on hardware the release
  parameter is *an index into the 1 kHz cycle counter*; matching that rate here is what
  makes a scheduled millisecond mean the millisecond the robot means. The same file's
  throw call passes `max_vel=140, gripper_release_ms=600`, which is also where the
  consumer's 140 deg/s ceiling comes from.
- **The schedule rides on the action, not on a new parameter.** `gymnasium.Wrapper.step`
  and `RenderCollection.step` both take exactly one positional argument and forward it by
  value, so a keyword or a second positional would not survive a wrapped env — and the
  recording path wraps every env it films. A test steps a schedule through
  `RenderCollection` and checks it reached the simulator.
- **The 1-D path allocates nothing.** A 1-D action becomes a read-only `np.broadcast_to`
  view over the period rather than a materialised array.
  `test_a_1d_action_is_held_for_every_tick_of_the_control_period` compares against an
  explicit tick-by-tick replay and asserts `np.array_equal` on `qpos` and `qvel`, rather
  than asserting closeness.

`TidyBotRobotEnv.step` gains the matching translation: its action-to-ctrl conversion is
split into `_action_to_ctrl` so each row of a schedule is converted the same way a lone
action is, against the state as it is *before* the period runs. A schedule re-commands
within a period; it does not re-close the loop on intra-period feedback.

**The consumer is `kinder-baselines` PR https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/pull/113**, which computes a toss's
release millisecond analytically and passes it here. That PR depends on this one; this
one stands alone.

**This one must merge first, and the dependency is harder than it reads.** The consumer
imports `CONTROL_SCHEDULE_TIMESTEP` from `kinder.envs.dynamic3d.mujoco_utils` at module
scope, so without this PR its `parameterized_skills` **fails to import at all** — a
downstream project that bumps its `kinder-baselines` pin without also bumping
`kindergarden` gets a deep `ImportError` behind a lazy import, far from the pin that
caused it. That happened downstream on 2026-08-13.

## Test plan

- [x] `python -m pytest tests/envs/dynamic3d/test_mujoco_utils.py -q` — **6 passed**
      (new file, 4 of those tests are this PR's)
- [x] `python -m pytest tests/envs/dynamic3d/test_tidybot3d_basic.py
      tests/envs/dynamic3d/test_tidybot3d_tossing.py
      tests/envs/dynamic3d/test_tidybot3d_ground.py
      tests/envs/dynamic3d/test_tidybot3d_utils.py -q` — 105 passed
- [x] `mypy src/kinder/envs/dynamic3d/mujoco_utils.py
      src/kinder/envs/dynamic3d/robots/tidybot_robot_env.py` — no issues in 2 source files
- [x] Downstream, at the consuming branch: `pytest kinder-models/tests/dynamic3d/tossing/
      -q` in `kinder-baselines` — **35 passed**

Formatting note: the changed files were formatted with `black` and `isort` at the repo's
own settings (line length 88, isort profile black). `run_autoformat.sh` was **not** run
repo-wide, deliberately — it currently rewrites ~28 unrelated files from tool-version
drift, and it never asserts a clean diff, so unformatted code does not fail CI anyway.

## Followup

- Only `TidyBotRobotEnv` translates a 2-D action today. `Fr3RobotEnv` and `Rby1aRobotEnv`
  override `step` with their own action parsing and would need the same one-line split
  before a schedule could reach them; neither has a caller that wants one yet.
- The schedule is uniform-in-time (one row per millisecond). A run-length form would be
  more compact for the common "hold, then switch once" case, but costs a second
  representation for no measured benefit at these sizes.
