### PR TITLE
kinder: restore the gripper linkage in set_state

### DIFF
--- a/src/kinder/envs/dynamic3d/envs.py
+++ b/src/kinder/envs/dynamic3d/envs.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import cv2 as cv
+import mujoco
 import numpy as np
 from gymnasium.spaces import Space
 from numpy.typing import NDArray
@@ -65,6 +66,14 @@ class TidyBot3DConfig(KinDEREnvConfig, metaclass=FinalConfigMeta):
     act_delta: bool = True
 
 
+# Enough steps for the finger linkage to come to rest under a held command.
+GRIPPER_SETTLE_STEPS = 200
+
+# Commands are continuous, the settle is not free, and the linkage pose varies smoothly
+# with the command, so cache on a grid rather than on the exact float.
+GRIPPER_COMMAND_QUANTUM = 0.01
+
+
 class ObjectCentricRobotEnv(ObjectCentricDynamic3DRobotEnv[TidyBot3DConfig]):
     """TidyBot 3D environment with mobile manipulation tasks."""
 
@@ -91,6 +100,7 @@ class ObjectCentricRobotEnv(ObjectCentricDynamic3DRobotEnv[TidyBot3DConfig]):
         self.show_images = show_images
         self.seed = seed
         self.config = config
+        self._gripper_linkage_cache: dict[float, NDArray[np.float64]] = {}
 
         # Parse task configuration
         if task_config_path is None:
@@ -1276,12 +1286,77 @@ class ObjectCentricRobotEnv(ObjectCentricDynamic3DRobotEnv[TidyBot3DConfig]):
         if set_arm_ctrl_targets:
             self._robot_env.ctrl["arm"][:] = robot_arm_pos
 
+
         gripper_pos = state.get(robot_obj, "pos_gripper")
         self._robot_env.ctrl["gripper"][:] = gripper_pos * 255.0
+        self._restore_gripper_linkage(gripper_pos)
 
         robot_arm_vel = [state.get(robot_obj, f"vel_arm_joint{i}") for i in range(1, 8)]
         self._robot_env.qvel["arm"][:] = robot_arm_vel
         self._robot_env.qvel["gripper"][:] = state.get(robot_obj, "vel_gripper")
+
+    def _gripper_linkage_qpos_addresses(self) -> list[int]:
+        """qpos addresses of every joint in the gripper, actuated or not.
+
+        A Robotiq 2F-85 has eight finger joints but only the two drivers are actuated,
+        so only those are named in qpos["gripper"]; the coupler, follower and
+        spring-link joints that trail them belong to no view at all. Found by walking
+        the body tree down from the drivers' parent rather than by joint name, so this
+        holds for any gripper hung off the end of the arm.
+        """
+        assert self._robot_env is not None
+        assert self._robot_env.qpos is not None
+        model = self._robot_env.sim.model.mj_model
+        driven = set(self._robot_env.qpos["gripper"].indices)
+        wrists = {
+            model.body_parentid[model.jnt_bodyid[joint]]
+            for joint in range(model.njnt)
+            if model.jnt_qposadr[joint] in driven
+        }
+        addresses = []
+        for joint in range(model.njnt):
+            body = model.jnt_bodyid[joint]
+            while body != 0 and body not in wrists:
+                body = model.body_parentid[body]
+            if body in wrists:
+                addresses.append(int(model.jnt_qposadr[joint]))
+        return sorted(addresses)
+
+    def _settled_gripper_linkage(self, gripper_pos: float) -> NDArray[np.float64]:
+        """The linkage pose this gripper command settles into, closing on nothing.
+
+        Cached, and quantized so that a continuously-sampled command cannot make every
+        call pay for a fresh settle.
+        """
+        assert self._robot_env is not None
+        quantized = (
+            round(gripper_pos / GRIPPER_COMMAND_QUANTUM) * GRIPPER_COMMAND_QUANTUM
+        )
+        if quantized not in self._gripper_linkage_cache:
+            model = self._robot_env.sim.model.mj_model
+            scratch = mujoco.MjData(model)  # pylint: disable=no-member
+            scratch.ctrl[self._robot_env.ctrl["gripper"].indices] = quantized * 255.0
+            for _ in range(GRIPPER_SETTLE_STEPS):
+                mujoco.mj_step(model, scratch)  # pylint: disable=no-member
+            addresses = self._gripper_linkage_qpos_addresses()
+            self._gripper_linkage_cache[quantized] = scratch.qpos[addresses].copy()
+        return self._gripper_linkage_cache[quantized]
+
+    def _restore_gripper_linkage(self, gripper_pos: float) -> None:
+        """Put the gripper's finger joints where this command settles them.
+
+        Without this, set_state restores the gripper *command* and leaves the fingers
+        wherever the previous episode left them, so the same state yields a different
+        simulator depending on history. The exact prior finger pose is not recoverable
+        -- the state records only the command -- but a canonical pose per command makes
+        set_state deterministic, which is what a planner relies on.
+        """
+        assert self._robot_env is not None
+        addresses = self._gripper_linkage_qpos_addresses()
+        if not addresses:
+            return
+        qpos = self._robot_env.sim.data.mj_data.qpos
+        qpos[addresses] = self._settled_gripper_linkage(gripper_pos)
 
 
 class ObjectCentricTidyBot3DEnv(ObjectCentricRobotEnv):

--- a/src/kinder/envs/dynamic3d/envs.py
+++ b/src/kinder/envs/dynamic3d/envs.py
@@ -66,12 +66,11 @@ class TidyBot3DConfig(KinDEREnvConfig, metaclass=FinalConfigMeta):
     act_delta: bool = True
 
 
-# Enough steps for the finger linkage to come to rest under a held command.
-GRIPPER_SETTLE_STEPS = 200
-
-# Commands are continuous, the settle is not free, and the linkage pose varies smoothly
-# with the command, so cache on a grid rather than on the exact float.
-GRIPPER_COMMAND_QUANTUM = 0.01
+# Enough steps for the finger linkage to come to rest under a held command: measured
+# stationary to under 1e-5 rad by 1600 steps for both a fully open and a fully closed
+# command, on the TidyBot and the FR3. A closing command is the slow one -- it is still
+# 0.32 rad short of its resting pose after 200.
+GRIPPER_SETTLE_STEPS = 2000
 
 
 class ObjectCentricRobotEnv(ObjectCentricDynamic3DRobotEnv[TidyBot3DConfig]):
@@ -1286,7 +1285,6 @@ class ObjectCentricRobotEnv(ObjectCentricDynamic3DRobotEnv[TidyBot3DConfig]):
         if set_arm_ctrl_targets:
             self._robot_env.ctrl["arm"][:] = robot_arm_pos
 
-
         gripper_pos = state.get(robot_obj, "pos_gripper")
         self._robot_env.ctrl["gripper"][:] = gripper_pos * 255.0
         self._restore_gripper_linkage(gripper_pos)
@@ -1301,8 +1299,9 @@ class ObjectCentricRobotEnv(ObjectCentricDynamic3DRobotEnv[TidyBot3DConfig]):
         A Robotiq 2F-85 has eight finger joints but only the two drivers are actuated,
         so only those are named in qpos["gripper"]; the coupler, follower and
         spring-link joints that trail them belong to no view at all. Found by walking
-        the body tree down from the drivers' parent rather than by joint name, so this
-        holds for any gripper hung off the end of the arm.
+        the body tree down from the drivers' parent rather than by joint name, so no
+        2F-85 joint name is baked in -- though both robots reaching this code (TidyBot
+        and FR3) do carry a 2F-85, so a different gripper is untested.
         """
         assert self._robot_env is not None
         assert self._robot_env.qpos is not None
@@ -1325,22 +1324,20 @@ class ObjectCentricRobotEnv(ObjectCentricDynamic3DRobotEnv[TidyBot3DConfig]):
     def _settled_gripper_linkage(self, gripper_pos: float) -> NDArray[np.float64]:
         """The linkage pose this gripper command settles into, closing on nothing.
 
-        Cached, and quantized so that a continuously-sampled command cannot make every
-        call pay for a fresh settle.
+        Cached on the exact command, so that the restored linkage always matches the
+        command restored alongside it. Every controller in the tree commands only a
+        fully open or a fully closed gripper, so the cache holds two entries.
         """
         assert self._robot_env is not None
-        quantized = (
-            round(gripper_pos / GRIPPER_COMMAND_QUANTUM) * GRIPPER_COMMAND_QUANTUM
-        )
-        if quantized not in self._gripper_linkage_cache:
+        if gripper_pos not in self._gripper_linkage_cache:
             model = self._robot_env.sim.model.mj_model
             scratch = mujoco.MjData(model)  # pylint: disable=no-member
-            scratch.ctrl[self._robot_env.ctrl["gripper"].indices] = quantized * 255.0
+            scratch.ctrl[self._robot_env.ctrl["gripper"].indices] = gripper_pos * 255.0
             for _ in range(GRIPPER_SETTLE_STEPS):
                 mujoco.mj_step(model, scratch)  # pylint: disable=no-member
             addresses = self._gripper_linkage_qpos_addresses()
-            self._gripper_linkage_cache[quantized] = scratch.qpos[addresses].copy()
-        return self._gripper_linkage_cache[quantized]
+            self._gripper_linkage_cache[gripper_pos] = scratch.qpos[addresses].copy()
+        return self._gripper_linkage_cache[gripper_pos]
 
     def _restore_gripper_linkage(self, gripper_pos: float) -> None:
         """Put the gripper's finger joints where this command settles them.

--- a/tests/envs/dynamic3d/test_franka3d_set_state.py
+++ b/tests/envs/dynamic3d/test_franka3d_set_state.py
@@ -1,0 +1,79 @@
+"""Tests that set_state fully restores the Franka FR3's gripper.
+
+The FR3 carries the same Robotiq 2F-85 as the TidyBot and restores its robot state
+through the same shared helper, so it had the same defect and is fixed by the same
+change; this pins that the shared path really does reach it.
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+import kinder
+from kinder.envs.dynamic3d.envs import ObjectCentricFranka3DEnv
+
+_TASK_CONFIG_PATH = (
+    Path(kinder.__path__[0])
+    / "envs"
+    / "dynamic3d"
+    / "tasks"
+    / "FrankaPickPlace3D"
+    / "FrankaPickPlace3D-o1.json"
+)
+
+_FINGER_JOINT_NAMES = [
+    f"robot_{side}_{link}_joint"
+    for side in ("left", "right")
+    for link in ("driver", "coupler", "follower", "spring_link")
+]
+
+_CLOSE_STEPS = 40
+
+
+def _make_env() -> ObjectCentricFranka3DEnv:
+    env = ObjectCentricFranka3DEnv(
+        num_objects=1,
+        task_config_path=str(_TASK_CONFIG_PATH),
+        scene_bg=False,
+        allow_state_access=True,
+    )
+    env.reset(seed=0)
+    return env
+
+
+def _finger_joint_positions(env: ObjectCentricFranka3DEnv) -> np.ndarray:
+    sim = env._robot_env.sim  # pylint: disable=protected-access
+    return np.array(
+        [
+            sim.data.mj_data.qpos[sim.model.get_joint_qpos_addr(name)]
+            for name in _FINGER_JOINT_NAMES
+        ]
+    )
+
+
+def _close_gripper_on_nothing(env: ObjectCentricFranka3DEnv) -> None:
+    # Arm is commanded as deltas (act_delta), the gripper absolutely, so zeros here
+    # hold the pose while the fingers shut.
+    action = np.zeros(8, dtype=np.float32)
+    action[7] = 1.0
+    for _ in range(_CLOSE_STEPS):
+        env.step(action)
+
+
+def test_fr3_set_state_restores_the_gripper_finger_joints():
+    """Restoring a state must put the fingers back, not just the gripper command."""
+    untouched = _make_env()
+    expected = _finger_joint_positions(untouched)
+    untouched.close()
+
+    env = _make_env()
+    initial_state = env.get_state()
+    _close_gripper_on_nothing(env)
+    env.set_state(initial_state)
+    restored = _finger_joint_positions(env)
+    env.close()
+
+    assert np.allclose(restored, expected, atol=1e-2), (
+        f"gripper fingers not restored: max |diff| = "
+        f"{np.abs(restored - expected).max():.4f} rad"
+    )

--- a/tests/envs/dynamic3d/test_tidybot3d_set_state.py
+++ b/tests/envs/dynamic3d/test_tidybot3d_set_state.py
@@ -1,0 +1,85 @@
+"""Tests that set_state fully restores the TidyBot's gripper."""
+
+from pathlib import Path
+
+import numpy as np
+
+from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv
+
+_TEST_TASKS = Path(__file__).parent / "test_tasks"
+
+# The Robotiq 2F-85 linkage: two driver joints plus the coupler, spring-link and
+# follower joints that trail them. Only the drivers are named in qpos["gripper"].
+_FINGER_JOINT_NAMES = [
+    f"robot_{side}_{link}_joint"
+    for side in ("left", "right")
+    for link in ("driver", "coupler", "follower", "spring_link")
+]
+
+_CLOSE_STEPS = 40
+
+
+def _make_env() -> ObjectCentricTidyBot3DEnv:
+    env = ObjectCentricTidyBot3DEnv(
+        num_objects=3,
+        task_config_path=str(_TEST_TASKS / "tidybot-ground-o3.json"),
+        allow_state_access=True,
+    )
+    env.reset(seed=0)
+    return env
+
+
+def _finger_joint_positions(env: ObjectCentricTidyBot3DEnv) -> np.ndarray:
+    sim = env._robot_env.sim  # pylint: disable=protected-access
+    return np.array(
+        [
+            sim.data.mj_data.qpos[sim.model.get_joint_qpos_addr(name)]
+            for name in _FINGER_JOINT_NAMES
+        ]
+    )
+
+
+def _close_gripper_on_nothing(env: ObjectCentricTidyBot3DEnv) -> None:
+    # Base and arm are commanded as deltas (act_delta), the gripper absolutely, so
+    # zeros here hold the pose while the fingers shut.
+    action = np.zeros(11)
+    action[10] = 1.0
+    for _ in range(_CLOSE_STEPS):
+        env.step(action)
+
+
+def test_set_state_restores_the_gripper_finger_joints():
+    """Restoring a state must put the fingers back, not just the gripper command."""
+    untouched = _make_env()
+    expected = _finger_joint_positions(untouched)
+    untouched.close()
+
+    env = _make_env()
+    initial_state = env.get_state()
+    _close_gripper_on_nothing(env)
+    env.set_state(initial_state)
+    restored = _finger_joint_positions(env)
+    env.close()
+
+    assert np.allclose(restored, expected, atol=1e-2), (
+        f"gripper fingers not restored: max |diff| = "
+        f"{np.abs(restored - expected).max():.4f} rad"
+    )
+
+
+def test_set_state_is_deterministic_regardless_of_gripper_history():
+    """The same state must yield the same simulator whatever the gripper just did."""
+    env = _make_env()
+    initial_state = env.get_state()
+    env.set_state(initial_state)
+    without_history = _finger_joint_positions(env)
+    env.close()
+
+    env = _make_env()
+    initial_state = env.get_state()
+    _close_gripper_on_nothing(env)
+    env.set_state(initial_state)
+    with_history = _finger_joint_positions(env)
+    env.close()
+
+    assert np.allclose(without_history, with_history, atol=1e-6)

--- a/tests/envs/dynamic3d/test_tidybot3d_set_state.py
+++ b/tests/envs/dynamic3d/test_tidybot3d_set_state.py
@@ -39,13 +39,21 @@ def _finger_joint_positions(env: ObjectCentricTidyBot3DEnv) -> np.ndarray:
     )
 
 
-def _close_gripper_on_nothing(env: ObjectCentricTidyBot3DEnv) -> None:
+def _command_gripper_on_nothing(env: ObjectCentricTidyBot3DEnv, gripper: float) -> None:
     # Base and arm are commanded as deltas (act_delta), the gripper absolutely, so
-    # zeros here hold the pose while the fingers shut.
-    action = np.zeros(11)
-    action[10] = 1.0
+    # zeros here hold the pose while the fingers move.
+    action = np.zeros(11, dtype=np.float32)
+    action[10] = gripper
     for _ in range(_CLOSE_STEPS):
         env.step(action)
+
+
+def _close_gripper_on_nothing(env: ObjectCentricTidyBot3DEnv) -> None:
+    _command_gripper_on_nothing(env, 1.0)
+
+
+def _open_gripper_on_nothing(env: ObjectCentricTidyBot3DEnv) -> None:
+    _command_gripper_on_nothing(env, 0.0)
 
 
 def test_set_state_restores_the_gripper_finger_joints():
@@ -63,6 +71,27 @@ def test_set_state_restores_the_gripper_finger_joints():
 
     assert np.allclose(restored, expected, atol=1e-2), (
         f"gripper fingers not restored: max |diff| = "
+        f"{np.abs(restored - expected).max():.4f} rad"
+    )
+
+
+def test_set_state_restores_a_closed_gripper():
+    """A closed command must restore closed fingers, not part-way ones."""
+    reference = _make_env()
+    _close_gripper_on_nothing(reference)
+    expected = _finger_joint_positions(reference)
+    reference.close()
+
+    env = _make_env()
+    _close_gripper_on_nothing(env)
+    closed_state = env.get_state()
+    _open_gripper_on_nothing(env)
+    env.set_state(closed_state)
+    restored = _finger_joint_positions(env)
+    env.close()
+
+    assert np.allclose(restored, expected, atol=1e-2), (
+        f"closed gripper not restored: max |diff| = "
         f"{np.abs(restored - expected).max():.4f} rad"
     )
 


### PR DESCRIPTION
**`set_state` restores the gripper's *command* but not its *fingers*, so the same state produces a different simulator depending on what happened before it.** A planner that restores a state, tries something, restores it again, and gets a different answer cannot plan. Measured downstream: a discarded toss attempt moves the next throw's landing point by ~3.6 cm.

## The bug

`ObjectCentricState` stores a single number for the gripper, `pos_gripper`, and that number is read back out of **`ctrl`** — the actuator command:

https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/blob/b0257e1c5ad34e931598f7acf280c5b957d1eb8e/src/kinder/envs/dynamic3d/envs.py#L1239

So the state records *what the gripper was told to do*, never *where its fingers are*.

Restoring that state writes `ctrl["gripper"]` and `qvel["gripper"]` — and nothing else:

https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/blob/b0257e1c5ad34e931598f7acf280c5b957d1eb8e/src/kinder/envs/dynamic3d/envs.py#L1280-L1284

**`qpos["gripper"]` is never written.** The eight finger joints keep whatever values the previous episode left in them, and survive every `set_state`.

TODO: drop gripper-command-vs-fingers-v1.mp4 here — http://agni:8765/gripper-command-vs-fingers-v1.mp4

The clip shows the state reporting `pos_gripper = 0.000`, fully open, while the fingers sit clamped at `0.787` rad.

### What it costs

Restoring one recorded state into two simulators — one fresh, one that had previously closed its gripper — and diffing:

| quantity | entries differing | max |
| --- | --- | --- |
| `qpos` | **8/39** | **0.784 rad** |
| `qvel` | 6/36 | 5.8e-4 |
| `ctrl` | 10/11 | 11.1 |
| `qacc_warmstart` | 31/36 | 3.0 |

Restoring each in isolation and replaying one fixed action sequence isolates which one matters. Only `qpos` does:

| restored | final cube x | error vs clean |
| --- | --- | --- |
| nothing | 1.8171 | −0.0184 |
| `ctrl` | 1.8171 | −0.0184 |
| `qacc_warmstart` | 1.8171 | −0.0184 |
| `act` | 1.8171 | −0.0184 |
| `qvel` | 1.8176 | −0.0179 |
| **`qpos`** | **1.8355** | **0.0000** |

Within `qpos`, only those eight finger joints differ.

### Why this never showed up in a rollout

In normal forward simulation the fingers are never *set* — the actuator is commanded every step and the linkage tracks it dynamically. Opening and closing have always worked. `set_state` is the only path that jumps state without letting physics get there, and a planner's `transition_fn` is its only heavy user. **This is a restore bug, not a rollout bug.**

### It is not TidyBot-specific

`FrankaPickPlace3D-o1`, same measurement: **8/22** `qpos` entries stale, max `0.7788` rad. `ObjectCentricFranka3DEnv` subclasses the same base and carries the same Robotiq 2F-85.

## The fix

`set_state` now puts the finger joints where the restored command settles them.

The exact prior finger pose is **not recoverable** — the state only ever recorded the command. What is recoverable is a *canonical* pose per command, which is enough: it makes `set_state` deterministic, which is the property a planner actually relies on.

The pose is computed by settling a scratch `MjData` under the restored command, so nothing is hardcoded per model, and the joints are found by walking the body tree down from the drivers rather than by name.

TODO: drop a before/after diagram here

Three things worth knowing about the implementation:

- **`mj_forward` does not suffice.** The coupler, follower and spring-link joints are held by *soft* `<equality>` constraints — solved as forces, not projected onto `qpos` — so `mj_forward` leaves all eight at zero for every command (`0.678` rad off for the closed command). A settle loop is required.
- **Closing settles far more slowly than opening**, so the first revision of this PR was silently wrong for the case that matters: at 200 steps a restored *closed* gripper came back `0.32` rad short of where it belongs. The settle is now 2000 steps, stationary to `<1e-5` by 1600. The earlier revision's headline `0.0016` rad only ever covered the open command, because only that case was tested.
- **The cache keys on the exact command**, not a quantised grid. Every controller quantises to `{0.0, 1.0}` before commanding — an audit of ~30 gripper-command writes across `kindergarden` and `kinder-baselines` found only literal `0`/`1` or `if pos_gripper > 0.2: return 1.0 else 0.0` — so the cache holds exactly two entries. A grid would have restored the 0.73 pose for a 0.734 command, leaving the fingers disagreeing with the command restored beside them.

### Result

Max stale finger joint immediately after `set_state`:

| robot | before | after (open) | after (closed) |
| --- | --- | --- | --- |
| TidyBot | 0.784045 | **0.000735** | **0.000065** |
| FR3 | 0.778808 | **0.000033** | **0.000057** |

Stale `qpos` entries: TidyBot `8/39` → `6/39` (residual all ≤ `7.4e-4` rad, the gap between the canonical settled pose and the scene's own not-quite-settled pose at reset — deterministic, which was the goal). FR3 `8/22` → **`0/22`**.

Cost: `72–82` ms the first time `set_state` sees a command (TidyBot; `42–49` ms FR3), `0.2` ms every time after. The observation vector, the type schema and all `1211` committed demos are untouched.

## Test plan

- [x] `tests/envs/dynamic3d/` — **355/355 passed**, 4 skipped (+2 new tests)
- [x] `tests/test_envs.py`, `test_wrappers.py`, `test_demo_loading.py` — **13/13 passed**, 1 skipped
- [x] Demo replay, both suites in full — **40/40 passed**. Neither suite calls `_set_state`, so committed demos cannot be affected.
- [x] New `test_tidybot3d_set_state.py` and `test_franka3d_set_state.py`, both red-green verified — the FR3 test fails by `0.7788` rad with the restore call removed
- [x] `mypy`, `pylint` (10.00/10), `isort`, `black` on the new test files

`black --check` on `envs.py` reports a **pre-existing** 302-line diff, byte-identical on unmodified `main` (unrelated `return\` continuations). Those rewrites are not shipped.

## Followup

- **The "gripper-agnostic" claim is untested.** The body-tree walk was written to work for any gripper hung off the arm, and it has now been exercised on a second robot — but the FR3 carries the *same* Robotiq 2F-85. A genuinely different gripper would be the real test.
- `ObjectCentricRBY1A3DEnv` is unaffected: its `_set_robot_state` restores base joints only and carries a `TODO` for the rest; `rby1a_robot_env.py` has no gripper views.
