### PR TITLE
Bump version to 0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kindergarden"
-version = "0.2.2"
+version = "0.2.3"
 description = "A robotics benchmark for physical reasoning."
 license = {text = "MIT"}
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bumps `version` to `0.2.3`. One line.

Ships the per-substep control schedule (#156): `MujocoEnv.step` now also accepts a 2-D
action covering the control period exactly, one row per `CONTROL_SCHEDULE_TIMESTEP`, at
1 kHz — the real Kinova arm's low-level servo period. `TidyBotRobotEnv` gains the
matching per-row action-to-ctrl translation. The 1-D path is unchanged and allocates
nothing.

**This release exists because a downstream PR cannot merge without it.**
`kinder-baselines` https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/pull/113
imports `CONTROL_SCHEDULE_TIMESTEP` from `kinder.envs.dynamic3d.mujoco_utils` **at module
scope**, and `kinder-models` depends on `kindergarden>=0.2.2` from **PyPI**, not from git.
So merging #156 into `main` does not reach that PR's CI at all: the constant exists on
`main` but is in no published release, and its `linting`, `static-type-checking` and
`unit-tests` jobs all fail at **collection** rather than on anything in their own diff.
https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/pull/115 is
stacked above it and inherits the same failure.

There is no way round this short of a release. A `git+https://` direct dependency would
bake a VCS URL into published package metadata and have to be reverted before merge;
`[tool.uv.sources]` is not honoured by the `uv pip install` interface CI's
`scripts/install_all.py` uses; and a CI step installing from git would touch `.github/`,
which makes selective CI fall back to all ten packages on every PR.

## Release plan

This repo has no publish workflow — only `ci.yml` — and `0.2.2` was cut by hand as a
one-line bump (#155) plus a `v0.2.2` tag. So the remaining steps are manual:

| # | Step | Repo |
| --- | --- | --- |
| 1 | Bump `version = "0.2.2"` → `"0.2.3"` in `pyproject.toml` | `PRPL/kindergarden` — **this PR** |
| 2 | Review and merge | `PRPL/kindergarden` |
| 3 | Tag `v0.2.3` on the merge commit, push the tag | `PRPL/kindergarden` |
| 4 | `python -m build`, then `twine upload` | → PyPI (not a repo) |
| 5 | Raise the floor `kindergarden>=0.2.2` → `>=0.2.3` in `kinder-models/pyproject.toml`, on kinder-baselines #113's branch `josh/feature/tossing-throw-controllers` | `PRPL/kinder-baselines` |
| 6 | Confirm kinder-baselines #113 and #115 go green | `PRPL/kinder-baselines` |
| 7 | Move the `reference/kindergarden` submodule gitlink to this merge commit | downstream consumer repo |

**Step 5 cannot merge before step 4 completes.** Raising the floor to a version that is
not yet on PyPI turns #113's collection error into a resolution error — the same red
check with a different message.

## Test plan

- [x] `python -m pytest tests/envs/dynamic3d/test_mujoco_utils.py -q` — **6 passed**
- [x] `python -m pytest tests/envs/dynamic3d/test_tidybot3d_basic.py
      tests/envs/dynamic3d/test_tidybot3d_tossing.py
      tests/envs/dynamic3d/test_tidybot3d_ground.py
      tests/envs/dynamic3d/test_tidybot3d_utils.py -q` — 105 passed

Both measured at #156's tip before merge. This PR changes one version string and no
executable line, so it carries no test of its own.

## Followup

- **Choice of `0.2.3` over `0.3.0` is a judgement call.** The substep schedule is purely
  additive — a 1-D action behaves identically, and the schedule rides on the action rather
  than on a new parameter, so no signature changed. That makes patch defensible, and it
  matches how #151 was released as `0.2.2`. It is a genuinely new capability, though, so
  `0.3.0` would signal it more loudly. Say the word and I will re-cut this as `0.3.0`.
- Only `TidyBotRobotEnv` translates a 2-D action today. `Fr3RobotEnv` and `Rby1aRobotEnv`
  override `step` with their own action parsing and would each need the same one-line
  split before a schedule could reach them; neither has a caller that wants one yet.
