### PR TITLE
Render offscreen on macOS instead of opening a window

### DIFF
--- a/src/kinder/__init__.py
+++ b/src/kinder/__init__.py
@@ -65,11 +65,15 @@ def register_all_environments() -> None:
     """
     # NOTE: ids must start with "kinder/" to be properly registered.
 
-    # Detect headless mode (no DISPLAY) and set OSMesa if needed
+    # Detect headless mode (no DISPLAY) and pick that platform's offscreen backend.
     if not os.environ.get("DISPLAY"):
         if sys.platform == "darwin":
-            os.environ["MUJOCO_GL"] = "glfw"
-            os.environ["PYOPENGL_PLATFORM"] = "glfw"
+            # cgl is the macOS counterpart of osmesa below. glfw would open an
+            # NSWindow, which is both pointless with no display and fatal when the
+            # render is driven from a worker thread, since AppKit allows NSWindow
+            # on the main thread only.
+            os.environ["MUJOCO_GL"] = "cgl"
+            os.environ["PYOPENGL_PLATFORM"] = "darwin"
         else:
             os.environ["MUJOCO_GL"] = "osmesa"
             os.environ["PYOPENGL_PLATFORM"] = "osmesa"

--- a/src/kinder/envs/dynamic3d/mujoco_utils.py
+++ b/src/kinder/envs/dynamic3d/mujoco_utils.py
@@ -879,14 +879,16 @@ class MjRenderContext:
                     EGLGLContext as GLContext,)
 
                 # TODO this needs testing on a Linux machine  # pylint: disable=fixme
-            elif _SYSTEM == "Darwin" and _MUJOCO_GL == "cgl":
+            elif _SYSTEM == "Darwin" and _MUJOCO_GL != "glfw":
                 from kinder.envs.dynamic3d.renderers.context.cgl_context import (  # type: ignore[assignment] # pylint: disable=line-too-long
                     CGLGLContext as GLContext,)
 
-                # cgl is accepted above on Darwin but used to fall through to GLFW,
-                # which creates an NSWindow. macOS allows that on the main thread
-                # only, so rendering from a worker thread -- what any env server
-                # does -- aborted the process instead of returning a frame.
+                # Everything on macOS except an explicit glfw request renders
+                # offscreen. GLFW creates an NSWindow, which AppKit permits on the
+                # main thread only, so rendering from a worker thread -- what any
+                # env server does -- aborts the process instead of returning a
+                # frame. That caught "cgl" (accepted above yet still routed to
+                # GLFW) and equally the unset default, which reads as "" here.
             else:
                 from kinder.envs.dynamic3d.renderers.context.glfw_context import (  # type: ignore[assignment] # pylint: disable=line-too-long
                     GLFWGLContext as GLContext,)

--- a/src/kinder/envs/dynamic3d/mujoco_utils.py
+++ b/src/kinder/envs/dynamic3d/mujoco_utils.py
@@ -879,6 +879,14 @@ class MjRenderContext:
                     EGLGLContext as GLContext,)
 
                 # TODO this needs testing on a Linux machine  # pylint: disable=fixme
+            elif _SYSTEM == "Darwin" and _MUJOCO_GL == "cgl":
+                from kinder.envs.dynamic3d.renderers.context.cgl_context import (  # type: ignore[assignment] # pylint: disable=line-too-long
+                    CGLGLContext as GLContext,)
+
+                # cgl is accepted above on Darwin but used to fall through to GLFW,
+                # which creates an NSWindow. macOS allows that on the main thread
+                # only, so rendering from a worker thread -- what any env server
+                # does -- aborted the process instead of returning a frame.
             else:
                 from kinder.envs.dynamic3d.renderers.context.glfw_context import (  # type: ignore[assignment] # pylint: disable=line-too-long
                     GLFWGLContext as GLContext,)

--- a/src/kinder/envs/dynamic3d/renderers/context/cgl_context.py
+++ b/src/kinder/envs/dynamic3d/renderers/context/cgl_context.py
@@ -1,0 +1,17 @@
+"""A CGL context for headless OpenGL rendering on macOS."""
+
+from mujoco.cgl import GLContext
+
+
+class CGLGLContext(GLContext):
+    """A CGL context for headless OpenGL rendering on macOS.
+
+    Unlike the GLFW context, this creates no window. macOS only allows NSWindow on the
+    main thread, so a GLFW context aborts the process outright when a render is driven
+    from a worker thread -- which is how anything serving an env renders.
+    """
+
+    def __init__(
+        self, max_width, max_height, device_id=-1
+    ):  # pylint: disable=unused-argument
+        super().__init__(max_width, max_height)


### PR DESCRIPTION
Any macOS render driven from a worker thread kills the process. In robocode that means every blackbox run: the env server answers each connection on its own thread, so the first `render_state` aborts the server, the agent loses its rendering tools, and the run burns its whole budget with no environment. One such run spent $19.96 over 639 turns and reported "the environment server was unreachable for the entire session".

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
    reason: 'NSWindow should only be instantiated on the main thread!'
  3   AppKit          -[NSWindow _initContent:styleMask:backing:defer:contentView:]
  5   libglfw.3.dylib _glfwCreateWindowCocoa
  6   libglfw.3.dylib glfwCreateWindow
```

## Cause

Rendering needs an OpenGL context. GLFW gets one by creating a window (an `NSWindow` on macOS, even when marked invisible); CGL gets one with no window at all. AppKit permits `NSWindow` on the main thread only, so the windowed path aborts as soon as a render runs on a worker thread.

macOS ends up on the windowed path twice over.

**1. `MjRenderContext` ignores what it accepts.** It validates `MUJOCO_GL` per platform, then selects a context class. Only Linux `osmesa` and Linux `egl` are special-cased; everything else falls through to `else: GLFWGLContext`. So `cgl` is accepted as valid on Darwin and then never routed anywhere. `cgl` is not the only accepted value there either -- eight are:

```python
("enable", "enabled", "on", "true", "1", "glfw", "")  +  ("cgl",)
```

`MUJOCO_GL` is read as `""` when unset, and `""` is in that list, so the plain default reaches GLFW as well.

**2. `register_all_environments()` asks for a window on a machine with no display.** The headless branch, whose comment says it selects OSMesa when `DISPLAY` is unset, picks the offscreen backend on Linux and the windowed one on macOS:

```python
if sys.platform == "darwin":
    os.environ["MUJOCO_GL"] = "glfw"     # windowed, in the "no display" branch
else:
    os.environ["MUJOCO_GL"] = "osmesa"   # offscreen
```

## Fix

- Add `cgl_context.py` wrapping `mujoco.cgl.GLContext`, the windowless context mujoco itself uses for headless macOS rendering.
- On Darwin, route everything except an explicit `glfw` request to it. That covers `cgl`, the unset default, and the generic synonyms. Asking for `glfw` by name still gets a window, for on-screen viewing.
- Use `cgl` for headless macOS in `register_all_environments()`, mirroring `osmesa` on Linux.

Linux and Windows paths are untouched.

## Testing

**Against a real robocode env server**, not just a unit test: started `env_server_runtime` on the config from the failed run, then connected two `BlackboxEnv` clients concurrently, mimicking the MCP render server and an agent test script.

| | Before | After |
|---|---|---|
| First `render_state` | server aborts | returns a frame |
| Server after two concurrent renders | dead | alive |
| Crash markers in server log | `NSInternalInconsistencyException` | 0 |
| Frames written | none | valid PNGs, visually correct |

**The default path**, with `MUJOCO_GL` unset, creating and resetting an env from a worker thread:

```
after registration MUJOCO_GL = cgl        (was glfw)
kinder sees _MUJOCO_GL = 'cgl'
RESULT: OK: rendered/reset on a worker thread
```

Also `mypy` clean over 145 files, `pylint` 10.00/10, black/isort/docformatter clean, `tests/envs/dynamic3d/` at 387 passed / 4 skipped, and a live robocode blackbox run now renders where it previously died.

## Notes for reviewers

- Linux cannot reproduce any of this. `osmesa` and `egl` keep their branches and neither is thread-affine, which is why only macOS users were affected.
- The validation list already advertised `cgl` on Darwin, so this makes the selection honour what validation always promised.
- **Known caveat, not fixed here:** a CGL context created on a worker thread and freed during interpreter shutdown segfaults in `mjr_freeContext` -> `glDeleteTextures`, because the free runs on the main thread. robocode is unaffected, since `env_server.py:321` stops the server with `proc.terminate()` and the shutdown GC never runs. It shows up only in standalone scripts that exit normally.
- I first suspected the caller's threading model and tried pinning renders to a dedicated thread in robocode. That was wrong and is not part of this change: the env server already constructs and renders each connection's env on the same thread, so the context was never misplaced. The GLFW fallback here was the only real defect.