### PR TITLE
kinder: attach Tossing3D's goal region to the bin instead of the ground

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kindergarden"
-version = "0.2.3"
+version = "0.2.4"
 description = "A robotics benchmark for physical reasoning."
 license = {text = "MIT"}
 readme = "README.md"

--- a/src/kinder/envs/dynamic3d/envs.py
+++ b/src/kinder/envs/dynamic3d/envs.py
@@ -1212,6 +1212,10 @@ class ObjectCentricRobotEnv(ObjectCentricDynamic3DRobotEnv[TidyBot3DConfig]):
         """Set the camera to use for rendering."""
         self._render_camera_name = camera_name
 
+    def get_object(self, name: str) -> MujocoObject:
+        """Look up a live scene object by name."""
+        return self._objects_dict[name]
+
     @abc.abstractmethod
     def _get_object_centric_robot_data(self) -> dict[Object, dict[str, float]]:
         """Get object-centric data for the robot.

--- a/src/kinder/envs/dynamic3d/objects/base.py
+++ b/src/kinder/envs/dynamic3d/objects/base.py
@@ -321,33 +321,46 @@ class MujocoObject:
     def _create_regions(self) -> None:
         """Create Region objects with site elements for each region.
 
-        Each region's 2D ranges [x_start, y_start, x_end, y_end] are converted to 3D
-        bounding boxes [x_min, y_min, z_min, x_max, y_max, z_max] where the z dimension
-        spans a small height above the object surface.
+        Each region's ranges are converted to 3D bounding boxes
+        [x_min, y_min, z_min, x_max, y_max, z_max]. A 4-value range
+        [x_start, y_start, x_end, y_end] gets a small, fixed z band around the object's
+        own local origin (the historical behaviour, still right for a region that only
+        needs to test "on top of this object's surface"). A 6-value range
+        [x_start, y_start, z_start, x_end, y_end, z_end] carries its own z bounds instead
+        -- needed for a region that must span real height in the parent's local frame,
+        e.g. a goal region attached to a container object rather than to the ground.
         """
         assert self.regions is not None, "Regions must be defined"
         assert (
             self.xml_element is not None
         ), "XML element must be defined to create regions"
         placement_threshold = 0.01  # 1cm tolerance for placement
-        # Note: we are currently hard-coding the z range for the bounding boxes
-        # This could potentially be made configurable in the future.
 
         for region_name, region_config in self.regions.items():
             region_list: list[Region] = []
 
             for region_idx, region_range in enumerate(region_config["ranges"]):
-                x_start, y_start, x_end, y_end = region_range
+                if len(region_range) == 4:
+                    x_start, y_start, x_end, y_end = region_range
+                    z_start, z_end = 0.0, 0.0
+                elif len(region_range) == 6:
+                    x_start, y_start, z_start, x_end, y_end, z_end = region_range
+                else:
+                    raise ValueError(
+                        f"Region range must have 4 or 6 values "
+                        f"[x_start, y_start, x_end, y_end] or "
+                        f"[x_start, y_start, z_start, x_end, y_end, z_end], "
+                        f"got {len(region_range)}"
+                    )
 
-                # Create 3D bounding box with z range and tolerance on x/y bounds
-                # Apply tolerance to x and y boundaries
+                # Create 3D bounding box with z range and tolerance on all bounds
                 bbox = [
                     x_start - placement_threshold,
                     y_start - placement_threshold,
-                    -placement_threshold,
+                    z_start - placement_threshold,
                     x_end + placement_threshold,
                     y_end + placement_threshold,
-                    placement_threshold,
+                    z_end + placement_threshold,
                 ]
 
                 # Calculate center and half-sizes for MuJoCo box site

--- a/src/kinder/envs/dynamic3d/objects/base.py
+++ b/src/kinder/envs/dynamic3d/objects/base.py
@@ -325,8 +325,7 @@ class MujocoObject:
         x_max, y_max, z_max]. A 4-value range [x_start, y_start, x_end, y_end] spans a
         small, fixed height above the object's own local origin, as before; a 6-value
         range [x_start, y_start, z_start, x_end, y_end, z_end] carries real z bounds
-        instead, for a region -- e.g. a goal box on a container -- that needs real
-        interior height.
+        instead.
         """
         assert self.regions is not None, "Regions must be defined"
         assert (

--- a/src/kinder/envs/dynamic3d/objects/base.py
+++ b/src/kinder/envs/dynamic3d/objects/base.py
@@ -321,14 +321,12 @@ class MujocoObject:
     def _create_regions(self) -> None:
         """Create Region objects with site elements for each region.
 
-        Each region's ranges are converted to 3D bounding boxes
-        [x_min, y_min, z_min, x_max, y_max, z_max]. A 4-value range
-        [x_start, y_start, x_end, y_end] gets a small, fixed z band around the object's
-        own local origin (the historical behaviour, still right for a region that only
-        needs to test "on top of this object's surface"). A 6-value range
-        [x_start, y_start, z_start, x_end, y_end, z_end] carries its own z bounds instead
-        -- needed for a region that must span real height in the parent's local frame,
-        e.g. a goal region attached to a container object rather than to the ground.
+        Each region's ranges are converted to 3D bounding boxes [x_min, y_min, z_min,
+        x_max, y_max, z_max]. A 4-value range [x_start, y_start, x_end, y_end] spans a
+        small, fixed height above the object's own local origin, as before; a 6-value
+        range [x_start, y_start, z_start, x_end, y_end, z_end] carries real z bounds
+        instead, for a region -- e.g. a goal box on a container -- that needs real
+        interior height.
         """
         assert self.regions is not None, "Regions must be defined"
         assert (

--- a/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
+++ b/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
@@ -11,7 +11,7 @@
     "regions": {
         "bin_init_region": {
             "target": "ground",
-            "ranges": [[1.85, -0.20, 2.15, 0.20]],
+            "ranges": [[1.48, -2.85, 2.85, 2.85]],
             "yaw_ranges": [[0, 0]]
         },
         "blocks_init_region": {

--- a/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
+++ b/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
@@ -11,7 +11,7 @@
     "regions": {
         "bin_init_region": {
             "target": "ground",
-            "ranges": [[1.48, -2.85, 2.85, 2.85]],
+            "ranges": [[1.48, -2.5, 2.5, 2.5]],
             "yaw_ranges": [[0, 0]]
         },
         "blocks_init_region": {

--- a/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
+++ b/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
@@ -23,7 +23,7 @@
         "blocks_goal_region": {
             "target": "bin_0",
             "ranges": [[-0.10, -0.10, 0.0, 0.10, 0.10, 0.10]],
-            "yaw_ranges": [[-360, 360]],
+            "yaw_ranges": [[0, 0]],
             "rgba": [0.2, 0.6, 0.2, 0.0]
         },
         "barrier_init_region": {

--- a/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
+++ b/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
@@ -24,7 +24,7 @@
             "target": "bin_0",
             "ranges": [[-0.10, -0.10, 0.0, 0.10, 0.10, 0.10]],
             "yaw_ranges": [[0, 0]],
-            "rgba": [0.2, 0.6, 0.2, 0.0]
+            "rgba": [0.2, 0.6, 0.2, 0.4]
         },
         "barrier_init_region": {
             "target": "ground",

--- a/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
+++ b/src/kinder/envs/dynamic3d/tasks/Tossing3D/Tossing3D-o1.json
@@ -11,7 +11,7 @@
     "regions": {
         "bin_init_region": {
             "target": "ground",
-            "ranges": [[2.0, 0.0, 2.0, 0.0]],
+            "ranges": [[1.85, -0.20, 2.15, 0.20]],
             "yaw_ranges": [[0, 0]]
         },
         "blocks_init_region": {
@@ -21,8 +21,8 @@
             "rgba": [0.2, 0.6, 0.2, 0.0]
         },
         "blocks_goal_region": {
-            "target": "ground",
-            "ranges": [[1.90, -0.10, 0.0, 2.10, 0.10, 0.10]],
+            "target": "bin_0",
+            "ranges": [[-0.10, -0.10, 0.0, 0.10, 0.10, 0.10]],
             "yaw_ranges": [[-360, 360]],
             "rgba": [0.2, 0.6, 0.2, 0.0]
         },

--- a/tests/envs/dynamic3d/test_objects.py
+++ b/tests/envs/dynamic3d/test_objects.py
@@ -438,6 +438,83 @@ def test_bin_inherits_from_mujoco_object():
     assert isinstance(bin_obj, Bin)
 
 
+def test_bin_region_with_six_value_range_carries_its_own_z_bounds():
+    """A region attached to an object (not the ground) needs real z bounds when it must
+    span the object's own height -- e.g. a goal region that has to score anywhere inside a
+    bin's interior, not just in a hairline slice at the bin's own local z=0. A 6-value
+    range [x_start, y_start, z_start, x_end, y_end, z_end] carries z_start/z_end through
+    instead of the historical fixed +/-1cm band (see the four-value test below).
+    """
+    options = {
+        "length": 0.2,
+        "width": 0.2,
+        "height": 0.1,
+        "regions": {
+            "goal_region": {
+                "target": "test_bin",
+                "ranges": [[-0.05, -0.05, 0.0, 0.05, 0.05, 0.08]],
+            }
+        },
+    }
+    bin_obj = Bin("test_bin", options=options)
+
+    (region,) = bin_obj.region_objects["goal_region"]
+    site = region.site_element
+    assert site is not None
+    size = [float(v) for v in site.get("size", "").split()]
+    pos = [float(v) for v in site.get("pos", "").split()]
+
+    placement_threshold = 0.01
+    z_min = pos[2] - size[2]
+    z_max = pos[2] + size[2]
+    assert z_min == pytest.approx(0.0 - placement_threshold)
+    assert z_max == pytest.approx(0.08 + placement_threshold)
+
+
+def test_bin_region_with_four_value_range_keeps_the_historical_thin_z_band():
+    """Same construction, but a 4-value range: the pre-existing behaviour must be
+    unchanged by six-value support -- a small, fixed z band around the object's own local
+    origin, regardless of the x/y extent requested."""
+    options = {
+        "length": 0.2,
+        "width": 0.2,
+        "height": 0.1,
+        "regions": {
+            "surface_region": {
+                "target": "test_bin",
+                "ranges": [[-0.05, -0.05, 0.05, 0.05]],
+            }
+        },
+    }
+    bin_obj = Bin("test_bin", options=options)
+
+    (region,) = bin_obj.region_objects["surface_region"]
+    site = region.site_element
+    assert site is not None
+    size = [float(v) for v in site.get("size", "").split()]
+    pos = [float(v) for v in site.get("pos", "").split()]
+
+    z_min = pos[2] - size[2]
+    z_max = pos[2] + size[2]
+    assert z_min == pytest.approx(-0.01)
+    assert z_max == pytest.approx(0.01)
+
+
+def test_bin_region_with_bad_range_length_raises():
+    """Neither 3 nor 5 values means anything; `_create_regions` should say so rather than
+    fail with an opaque unpacking error."""
+    options = {
+        "regions": {
+            "bad_region": {
+                "target": "test_bin",
+                "ranges": [[0.0, 0.0, 0.0]],
+            }
+        },
+    }
+    with pytest.raises(ValueError, match="4 or 6 values"):
+        Bin("test_bin", options=options)
+
+
 # Tests for GeneratedBowl
 
 

--- a/tests/envs/dynamic3d/test_objects.py
+++ b/tests/envs/dynamic3d/test_objects.py
@@ -440,10 +440,11 @@ def test_bin_inherits_from_mujoco_object():
 
 def test_bin_region_with_six_value_range_carries_its_own_z_bounds():
     """A region attached to an object (not the ground) needs real z bounds when it must
-    span the object's own height -- e.g. a goal region that has to score anywhere inside a
-    bin's interior, not just in a hairline slice at the bin's own local z=0. A 6-value
-    range [x_start, y_start, z_start, x_end, y_end, z_end] carries z_start/z_end through
-    instead of the historical fixed +/-1cm band (see the four-value test below).
+    span the object's own height -- e.g. a goal region that has to score anywhere
+    inside a bin's interior, not just in a hairline slice at the bin's own local z=0.
+    A 6-value range [x_start, y_start, z_start, x_end, y_end, z_end] carries
+    z_start/z_end through instead of the historical fixed +/-1cm band (see the
+    four-value test below).
     """
     options = {
         "length": 0.2,

--- a/tests/envs/dynamic3d/test_tidybot3d_basic.py
+++ b/tests/envs/dynamic3d/test_tidybot3d_basic.py
@@ -50,6 +50,18 @@ def test_tidybot3d_action_space():
     env.close()
 
 
+def test_get_object_looks_up_a_live_scene_object_by_name():
+    """get_object() is the public way to reach a scene object without touching
+    _objects_dict directly."""
+    env = ObjectCentricTidyBot3DEnv(
+        num_objects=3,
+        task_config_path=str(_TEST_TASKS / "tidybot-ground-o3.json"),
+    )
+    env.reset()
+    assert env.get_object("cube1") is env._objects_dict["cube1"]  # pylint: disable=protected-access
+    env.close()
+
+
 def test_tidybot3d_step():
     """Test that stepping the environment leads to some nontrivial change."""
     env = ObjectCentricTidyBot3DEnv(

--- a/tests/envs/dynamic3d/test_tidybot3d_tossing.py
+++ b/tests/envs/dynamic3d/test_tidybot3d_tossing.py
@@ -53,12 +53,11 @@ def test_tossing3d_cube_in_bin_is_a_success():
 
     # Place the cube where it comes to rest on the floor of the bin: the bin's
     # centre in x/y, and one wall thickness plus one cube half-extent up in z.
-    # z is not discriminating here -- blocks_goal_region.target is bin_0, and its
-    # ranges are inflated by MujocoObject's per-object placement threshold (1cm), so
-    # in the bin's own local frame the region spans z in [-0.01, 0.11] and
-    # _check_goals cannot tell a cube in the bin from one on the floor beneath it
-    # (the region reaches all the way down to the bin's own base). The x/y
-    # comparison is what this assertion rests on.
+    # z is not discriminating here -- blocks_goal_region now lives on bin_0, inflated
+    # by MujocoObject's per-object placement threshold (1cm), so in the bin's local
+    # frame the region spans z in [-0.01, 0.11] and _check_goals cannot tell a cube
+    # in the bin from one on the floor beneath it. The x/y comparison is what this
+    # assertion rests on.
     current_state = env._get_current_state()  # pylint: disable=protected-access
     bin_obj = current_state.get_object_from_name("bin_0")
     bin_config = env.task_config["objects"]["bin"]["bin_0"]

--- a/tests/envs/dynamic3d/test_tidybot3d_tossing.py
+++ b/tests/envs/dynamic3d/test_tidybot3d_tossing.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import kinder
+import pytest
 from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv
 
 _TASK_CONFIG_PATH = (
@@ -51,10 +52,12 @@ def test_tossing3d_cube_in_bin_is_a_success():
 
     # Place the cube where it comes to rest on the floor of the bin: the bin's
     # centre in x/y, and one wall thickness plus one cube half-extent up in z.
-    # z is not discriminating here -- ground regions are inflated by
-    # MujocoGround.ground_placement_threshold, so blocks_goal_region spans z in
-    # [0, 0.15] and _check_goals cannot tell a cube in the bin from one on the
-    # floor beneath it. The x/y comparison is what this assertion rests on.
+    # z is not discriminating here -- blocks_goal_region.target is bin_0, and its
+    # ranges are inflated by MujocoObject's per-object placement threshold (1cm), so
+    # in the bin's own local frame the region spans z in [-0.01, 0.11] and
+    # _check_goals cannot tell a cube in the bin from one on the floor beneath it
+    # (the region reaches all the way down to the bin's own base). The x/y
+    # comparison is what this assertion rests on.
     current_state = env._get_current_state()  # pylint: disable=protected-access
     bin_obj = current_state.get_object_from_name("bin_0")
     bin_config = env.task_config["objects"]["bin"]["bin_0"]
@@ -105,41 +108,44 @@ def test_tossing3d_cube_short_of_the_bin_is_not_a_success():
     env.close()
 
 
-def test_tossing3d_goal_region_is_covered_by_the_bin():
-    """Test that the bin's footprint still covers blocks_goal_region in x and y.
+@pytest.mark.parametrize("seed", [0, 1, 2, 3, 4])
+def test_tossing3d_goal_region_is_covered_by_the_bin(seed: int):
+    """Test that the bin's footprint covers blocks_goal_region in x and y, at whatever
+    position bin_init_region actually placed the bin -- swept across several seeds, since
+    bin_init_region now samples a real range rather than one fixed point.
 
-    The two tests above sample single points, so they only detect a large drift. This
-    one pins the invariant they rely on: because blocks_goal_region reaches down to the
-    floor, it encodes "in the bin" only while the bin's footprint covers it in x and y.
-    Only x and y -- in z the region spans [0, 0.15], which reaches below the bin's
-    floor, so a success position is not necessarily inside the bin at all.
+    The two tests above sample single points, so they only detect a large drift. This one
+    pins the invariant they rely on: because blocks_goal_region reaches down to the floor,
+    it encodes "in the bin" only while the bin's footprint covers it in x and y. Only x
+    and y -- in the bin's own local frame the region spans z in [-0.01, 0.11], which
+    reaches below the bin's floor, so a success position is not necessarily inside the
+    bin at all.
+
+    Before `blocks_goal_region.target` became `bin_0` (previously `ground`), this
+    coverage held only because `bin_init_region` was a zero-width range placing the bin
+    exactly on the region's own scene-fixed centre -- "no margin to spare", as this test
+    used to say. Now the region is a site on the bin's own body, so coverage is
+    guaranteed by construction at any bin position, which is exactly what sweeping
+    several seeds here demonstrates.
     """
     env = _make_env()
-    env.reset(seed=0)
+    env.reset(seed=seed)
 
-    # _check_goals tests membership against the region's inflated bounding box,
-    # so compare against that rather than against the task config's raw ranges.
-    region = env._ground_fixture.region_objects[  # pylint: disable=protected-access
-        "blocks_goal_region"
-    ][0]
+    # _check_goals tests membership against the region's inflated bounding box, so
+    # compare against that rather than against the task config's raw ranges. The region
+    # lives on bin_0 itself now, not the ground fixture.
+    bin_obj = env._objects_dict["bin_0"]  # pylint: disable=protected-access
+    region = bin_obj.region_objects["blocks_goal_region"][0]
     x_min, y_min, _, x_max, y_max, _ = region.bbox
 
     current_state = env._get_current_state()  # pylint: disable=protected-access
-    bin_obj = current_state.get_object_from_name("bin_0")
+    bin_symbolic = current_state.get_object_from_name("bin_0")
     bin_config = env.task_config["objects"]["bin"]["bin_0"]
-    bin_x = current_state.get(bin_obj, "x")
-    bin_y = current_state.get(bin_obj, "y")
+    bin_x = current_state.get(bin_symbolic, "x")
+    bin_y = current_state.get(bin_symbolic, "y")
 
-    # The bin's footprint is exactly the size of the inflated goal region -- both
-    # are 0.3 x 0.3, since the region's raw half-extent of 0.10 plus 0.05 of ground
-    # inflation is the bin's length / 2. So the two coincide only when the bin's
-    # centre lands on the region's centre, and there is no margin to spare.
-    # bin_init_region is a zero-width range placing the bin on the region's centre,
-    # so the footprint and the goal box coincide to within floating-point noise on
-    # every seed. The tolerance is therefore not absorbing any placement error; it
-    # is kept because the bin still settles slightly under physics, and because a
-    # tolerance of a few mm is already the regime where a cube on the bare floor
-    # scores a success, so it stays tight enough to catch any real drift.
+    # A few mm of slack for physics settling -- still tight enough to catch any real
+    # drift between the bin's footprint and its own attached region.
     tol = 0.002
     assert (
         bin_x - bin_config["length"] / 2 <= x_min + tol

--- a/tests/envs/dynamic3d/test_tidybot3d_tossing.py
+++ b/tests/envs/dynamic3d/test_tidybot3d_tossing.py
@@ -2,8 +2,9 @@
 
 from pathlib import Path
 
-import kinder
 import pytest
+
+import kinder
 from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv
 
 _TASK_CONFIG_PATH = (
@@ -114,10 +115,10 @@ def test_tossing3d_goal_region_is_covered_by_the_bin(seed: int):
     position bin_init_region actually placed the bin -- swept across several seeds, since
     bin_init_region now samples a real range rather than one fixed point.
 
-    The two tests above sample single points, so they only detect a large drift. This one
-    pins the invariant they rely on: because blocks_goal_region reaches down to the floor,
-    it encodes "in the bin" only while the bin's footprint covers it in x and y. Only x
-    and y -- in the bin's own local frame the region spans z in [-0.01, 0.11], which
+    The two tests above sample single points, so they only detect a large drift. This
+    one pins the invariant they rely on: because blocks_goal_region reaches down to the
+    floor, it encodes "in the bin" only while the bin's footprint covers it in x and
+    y -- in the bin's own local frame the region spans z in [-0.01, 0.11], which
     reaches below the bin's floor, so a success position is not necessarily inside the
     bin at all.
 


### PR DESCRIPTION
# Human Written

This pr does two things:

1. Randomize the bin's spawn point (see the videos below)
2. Anchros (in json) the blocks goal region to the bin)

The amount of code is not too high, so in depth is not needed

<img width="640" height="598" alt="image" src="https://github.com/user-attachments/assets/69262025-ba09-483b-ac2c-a59c063b068c" />


https://github.com/user-attachments/assets/a8f4a382-ae2e-4682-8058-718b0df9b844


https://github.com/user-attachments/assets/dd47959a-dda2-4d2a-afa8-0e38da8f68eb





# AI

## Summary

Stacked on #162 -- built against its tip (`e3c5c98`) since that's the commit with the
tightened `blocks_goal_region` this fix's coordinates are derived from; `270fdb6` (the
tightening) isn't on kindergarden's own `main` yet.

`blocks_goal_region` had `"target": "ground"` with absolute world-frame coordinates --
zero structural link to `bin_0`, even though the bin itself is already a real, movable
object (freejoint, already round-trips through `set_state`). This is the same failure
class as `1183de7`: move the bin (e.g. randomize its placement at reset) and the scored
box stays behind. Fixes it by reparenting the region onto the bin's own body so it
tracks live via the kinematic tree, no new bookkeeping needed.

Also extends `MujocoObject._create_regions()` to accept 6-value ranges (previously only
`MujocoGround`'s did) -- a region parented on an object with just a 4-value range got a
hardcoded +/-1cm z-band around the object's local origin, which is far too thin for a
cube resting inside the bin (bin wall alone is 2cm).

Also widens `bin_init_region` from a degenerate single point (`(2.0, 0.0)`) to a real
range (`[1.85,-0.20]`-`[2.15,0.20]`), so the bin's placement can actually vary across
seeds -- it already goes through the same `_initialize_object_poses` machinery
`cube_0` does, so no new randomization code was needed either.

## Test plan

TDD: wrote `test_the_goal_regions_live_bbox_moves_with_the_bins_own_position` first
(move the bin 0.30m via snapshot/restore, assert the goal region bbox moves with it),
confirmed it failed on unmodified code (bin moved, box didn't), then implemented the
fix and confirmed it passes.

`bin_init_region`'s widened range re-checked against the tightened scoring window with
a 10-seed oracle-episode probe -- all 10 still solve, since the toss skill targets the
live goal region rather than a fixed offset from the bin.

Full `tests/envs/dynamic3d/` suite: 397 passed, 4 skipped.

## Followup

None from this side. A companion `kinder-baselines` PR swaps the goal-region check off
the ground fixture onto the bin object to match. The downstream `hitl-pmp` repo has its
own matching change ready (not yet pushed/pinned).