### PR TITLE
Require the cubes to be on the beam for BalanceBeam3D to be solved

### DIFF
--- a/src/kinder/envs/dynamic3d/objects/generated_objects.py
+++ b/src/kinder/envs/dynamic3d/objects/generated_objects.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import numpy as np
 from numpy.typing import NDArray
 from relational_structs import Object
+from scipy.spatial.transform import Rotation
 
 from kinder.envs.dynamic3d.mujoco_utils import MujocoEnv
 from kinder.envs.dynamic3d.object_types import MujocoMovableObjectType
@@ -390,7 +391,47 @@ class GeneratedSeesaw(MujocoObject):
         self.xml_element = self._create_xml_element()
 
         if self.regions is not None:
+            # A region attached to a seesaw may leave its ranges out, in which case it
+            # covers the beam. A task that wants "these objects end up on the beam" can
+            # then say so with the ordinary `on` predicate without restating geometry
+            # the seesaw already owns, and without going stale when that geometry
+            # changes. Rebuilt rather than mutated: the dicts come straight from the
+            # task config and are shared with it.
+            self.regions = {
+                name: (
+                    config
+                    if config.get("ranges")
+                    else {**config, "ranges": [self.beam_surface_range()]}
+                )
+                for name, config in self.regions.items()
+            }
             self._create_regions()
+
+    def beam_surface_range(self) -> list[float]:
+        """The volume an object occupies when it is resting on the beam.
+
+        Returns ``[x_min, y_min, z_min, x_max, y_max, z_max]`` in the seesaw's own
+        frame, so the beam runs along x whatever yaw the task spawns the seesaw with.
+
+        The floor sits at the pivot rather than at the beam's top surface. The beam
+        tilts, so an object near the end rides below the level surface by up to
+        ``beam_length / 2 * sin(tilt)`` -- 1.6cm at the 5 degrees BalanceBeam3D calls
+        balanced, more than the 1cm of slack region bounds are given. The pivot is
+        still well clear of anything lying on the ground beside or beneath the beam.
+
+        The ceiling is deliberately generous: gravity decides what is resting on the
+        beam, so it only has to exclude something held far above it.
+        """
+        half_length = self.beam_length / 2
+        half_width = self.beam_width / 2
+        return [
+            -half_length,
+            -half_width,
+            self.pivot_height,
+            half_length,
+            half_width,
+            self.pivot_height + self.beam_clearance + half_length,
+        ]
 
     def _generate_and_save_pivot_mesh(self) -> str:
         """Generate triangular prism pivot mesh and save to a temporary OBJ file.
@@ -673,29 +714,44 @@ class GeneratedSeesaw(MujocoObject):
         if self.env is None:
             raise ValueError("Environment must be set to check object position")
 
-        # Get seesaw position
-        seesaw_pos, _ = self.env.get_joint_pos_quat(self.joint_name)
+        # Get seesaw pose. The beam runs along the seesaw's local +x, which is not
+        # world +x whenever the task spawns the seesaw with a yaw (BalanceBeam3D-o3
+        # pins yaw to 90 degrees), so the extent checks below have to be made in the
+        # seesaw's frame. Comparing world offsets instead swaps the length and width
+        # limits, and a block placed correctly along the beam reads as off it.
+        seesaw_pos, seesaw_quat = self.env.get_joint_pos_quat(self.joint_name)
 
-        obj_x, obj_y, obj_z = object_position[0], object_position[1], object_position[2]
+        # MuJoCo quaternions are (w, x, y, z); scipy wants (x, y, z, w).
+        rotation = Rotation.from_quat(
+            [seesaw_quat[1], seesaw_quat[2], seesaw_quat[3], seesaw_quat[0]]
+        )
+        # Yaw only: the beam pitches about its hinge as it tilts, and folding that
+        # rotation in would shrink the footprint an object has to sit within just
+        # because the beam is not level. The pivot stays upright regardless.
+        yaw = rotation.as_euler("xyz")[2]
+        world_offset = np.asarray(object_position, dtype=np.float64) - np.asarray(
+            seesaw_pos, dtype=np.float64
+        )
+        local_offset = Rotation.from_euler("z", -yaw).apply(world_offset)
 
         beam_half_length = self.beam_length / 2
         beam_half_width = self.beam_width / 2
         min_height = seesaw_pos[2] + self.pivot_height * 0.5
 
-        # Check X is within beam length
-        x_offset = obj_x - seesaw_pos[0]
+        # Check the along-beam offset is within the beam length
         if not (
-            -beam_half_length - tolerance < x_offset < beam_half_length + tolerance
+            -beam_half_length - tolerance
+            < local_offset[0]
+            < beam_half_length + tolerance
         ):
             return False
 
-        # Check Y is within beam width
-        y_offset = abs(obj_y - seesaw_pos[1])
-        if not y_offset < beam_half_width + tolerance:
+        # Check the across-beam offset is within the beam width
+        if not abs(local_offset[1]) < beam_half_width + tolerance:
             return False
 
         # Check Z is above pivot (object is resting on beam)
-        if not obj_z > min_height:
+        if not object_position[2] > min_height:
             return False
 
         return True

--- a/src/kinder/envs/dynamic3d/tasks/BalanceBeam3D/BalanceBeam3D-o3.json
+++ b/src/kinder/envs/dynamic3d/tasks/BalanceBeam3D/BalanceBeam3D-o3.json
@@ -16,6 +16,10 @@
             "yaw_ranges": [[90, 90]],
             "rgba": [0.2, 0.6, 0.2, 0.0]
         },
+        "beam_goal_region": {
+            "target": "seesaw_1",
+            "rgba": [0.2, 0.6, 0.2, 0.4]
+        },
         "blocks_init_region": {
             "target": "ground",
             "ranges": [[0.5, -0.25, 0.75, 0.25]],
@@ -84,6 +88,10 @@
         ["on", "large_block", "blocks_init_region"]
     ],
     "goal_state": [
+        "and",
+        ["on", "small_block_1", "beam_goal_region"],
+        ["on", "small_block_2", "beam_goal_region"],
+        ["on", "large_block", "beam_goal_region"],
         ["balanced", "seesaw_1", 5.0]
     ]
 }

--- a/tests/envs/dynamic3d/test_tidybot3d_balance.py
+++ b/tests/envs/dynamic3d/test_tidybot3d_balance.py
@@ -11,6 +11,7 @@ from typing import Any
 import numpy as np
 from numpy.typing import NDArray
 from relational_structs import Object, ObjectCentricState
+from scipy.spatial.transform import Rotation
 
 from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv
 from kinder.envs.dynamic3d.objects.generated_objects import GeneratedSeesaw
@@ -380,3 +381,225 @@ def test_tidybot3d_balance_reward_negative_per_timestep():
     assert reward < 0, "Reward should be negative per timestep"
 
     env.close()
+
+
+# The shipped variant, as opposed to the o4 fixture above. It spawns the seesaw with a
+# 90 degree yaw, which is what makes it the interesting case here.
+_SHIPPED_TASK = "tasks/BalanceBeam3D/BalanceBeam3D-o3.json"
+
+
+def _get_shipped_balancebeam_env() -> ObjectCentricTidyBot3DEnv:
+    """Create the BalanceBeam3D-o3 environment that ships with kinder."""
+    return ObjectCentricTidyBot3DEnv(
+        scene_type="balance",
+        num_objects=3,
+        task_config_path=_SHIPPED_TASK,
+        allow_state_access=True,
+    )
+
+
+def _seesaw_yaw(env: ObjectCentricTidyBot3DEnv, seesaw: GeneratedSeesaw) -> float:
+    """Return the seesaw's yaw in radians."""
+    _pos, quat = env._robot_env.get_joint_pos_quat(  # pylint: disable=protected-access
+        seesaw.joint_name
+    )
+    # MuJoCo quaternions are (w, x, y, z); scipy wants (x, y, z, w).
+    rotation = Rotation.from_quat([quat[1], quat[2], quat[3], quat[0]])
+    return float(rotation.as_euler("xyz")[2])
+
+
+def test_balancebeam3d_is_not_solved_by_doing_nothing():
+    """The shipped task must not be satisfied by the state it starts in.
+
+    An empty beam sits level, so a goal of ["balanced", ...] alone is true at reset:
+    every policy, including one that emits zero actions, scored a solve. The goal has
+    to name the cubes it wants on the beam for the task to mean anything.
+    """
+    env = _get_shipped_balancebeam_env()
+    env.reset(seed=0)
+
+    assert not env._check_goals()  # pylint: disable=protected-access
+
+    action_shape = env.action_space.shape
+    assert action_shape is not None
+    null_action = np.zeros(action_shape, dtype=np.float32)
+    for _ in range(20):
+        env.step(null_action)
+        assert not env._check_goals()  # pylint: disable=protected-access
+
+    env.close()
+
+
+def test_balancebeam3d_is_solved_when_the_cubes_sit_balanced_on_the_beam():
+    """Placing the three cubes to balance the beam satisfies the shipped goal.
+
+    The counterpart to the test above: tightening the goal must not make the task
+    impossible. Offsets are along the beam, so this also covers the yawed seesaw.
+    """
+    env = _get_shipped_balancebeam_env()
+    env.reset(seed=0)
+
+    seesaw = env._objects_dict["seesaw_1"]  # pylint: disable=protected-access
+    assert isinstance(seesaw, GeneratedSeesaw)
+    seesaw_pos, _ = (
+        env._robot_env.get_joint_pos_quat(  # pylint: disable=protected-access
+            seesaw.joint_name
+        )
+    )
+    yaw = _seesaw_yaw(env, seesaw)
+    beam_height = seesaw.pivot_height + seesaw.beam_clearance + seesaw.beam_thickness
+    placement_distance = (seesaw.beam_length / 2) * 0.7
+
+    state = env._get_current_state().copy()  # pylint: disable=protected-access
+
+    def place(name: str, along: float, across: float = 0.0) -> Object:
+        """Put a cube on the beam at (along, across) in the seesaw's own frame."""
+        block = state.get_object_from_name(name)
+        offset = Rotation.from_euler("z", yaw).apply([along, across, 0.0])
+        _place_block_on_seesaw(
+            block,
+            state,
+            np.array(
+                [seesaw_pos[0] + offset[0], seesaw_pos[1] + offset[1], seesaw_pos[2]]
+            ),
+            beam_height,
+            x_offset=0.0,
+        )
+        return block
+
+    # Two small cubes (0.05 each) against one large cube (0.10) at equal distances.
+    small_block_size = 0.012
+    blocks = [
+        place("small_block_1", -placement_distance, -small_block_size),
+        place("small_block_2", -placement_distance, small_block_size),
+        place("large_block", placement_distance),
+    ]
+    env.set_state(state)
+
+    action_shape = env.action_space.shape
+    assert action_shape is not None
+    null_action = np.zeros(action_shape, dtype=np.float32)
+    for _ in range(50):
+        env.step(null_action)
+
+    final_state = env._get_current_state()  # pylint: disable=protected-access
+    for block in blocks:
+        _assert_block_on_seesaw(block, final_state, seesaw)
+    assert seesaw.is_balanced(5.0)
+    assert env._check_goals()  # pylint: disable=protected-access
+
+    env.close()
+
+
+def test_is_object_on_beam_measures_along_the_beam_not_along_world_x():
+    """A yawed beam's extents follow the beam, not the world axes.
+
+    The check compared world x against half the beam *length* and world y against half
+    its *width*. On the shipped task the seesaw is yawed 90 degrees, so those two limits
+    were swapped and a cube resting mid-beam read as off it -- 0.18m of beam judged
+    against a 0.035m half-width.
+    """
+    env = _get_shipped_balancebeam_env()
+    env.reset(seed=0)
+
+    seesaw = env._objects_dict["seesaw_1"]  # pylint: disable=protected-access
+    assert isinstance(seesaw, GeneratedSeesaw)
+    seesaw_pos, _ = (
+        env._robot_env.get_joint_pos_quat(  # pylint: disable=protected-access
+            seesaw.joint_name
+        )
+    )
+    yaw = _seesaw_yaw(env, seesaw)
+    assert not np.isclose(yaw, 0.0), "this task is only interesting while it is yawed"
+
+    beam_height = seesaw.pivot_height + seesaw.beam_clearance + seesaw.beam_thickness
+    height = seesaw_pos[2] + beam_height + 0.015
+
+    def world_point(along: float, across: float) -> NDArray[np.float32]:
+        offset = Rotation.from_euler("z", yaw).apply([along, across, 0.0])
+        return np.array(
+            [seesaw_pos[0] + offset[0], seesaw_pos[1] + offset[1], height],
+            dtype=np.float32,
+        )
+
+    near_the_end = (seesaw.beam_length / 2) * 0.9
+    assert seesaw.is_object_on_beam(world_point(near_the_end, 0.0))
+    assert seesaw.is_object_on_beam(world_point(-near_the_end, 0.0))
+    # Past the end of the beam, and off its side, are both still off the beam.
+    assert not seesaw.is_object_on_beam(world_point(seesaw.beam_length, 0.0))
+    assert not seesaw.is_object_on_beam(world_point(0.0, seesaw.beam_width))
+
+    env.close()
+
+
+def test_beam_goal_region_is_derived_from_the_seesaw_it_is_attached_to():
+    """The goal region's extents come from the beam, not from numbers in the task JSON.
+
+    BalanceBeam3D-o3 declares `beam_goal_region` with a target and no ranges, so a task
+    never restates beam_length or beam_width and the region cannot go stale when the
+    seesaw's geometry changes.
+    """
+    env = _get_shipped_balancebeam_env()
+    env.reset(seed=0)
+
+    seesaw = env._objects_dict["seesaw_1"]  # pylint: disable=protected-access
+    assert isinstance(seesaw, GeneratedSeesaw)
+
+    x_min, y_min, _z_min, x_max, y_max, _z_max = seesaw.beam_surface_range()
+    assert x_max - x_min == seesaw.beam_length
+    assert y_max - y_min == seesaw.beam_width
+
+    # And the region actually built from it tracks the beam through the seesaw's yaw:
+    # at 90 degrees the beam's length lies along world y, its width along world x.
+    (region,) = seesaw.region_objects["beam_goal_region"]
+    world = region.bbox
+    tolerance = 0.01  # placement_threshold, applied to every bound by _create_regions
+    # Within a millimetre: the seesaw is a free body that has settled under physics, so
+    # its yaw is a hair off 90 degrees and the world-aligned bound inflates by that much.
+    assert np.isclose(world[3] - world[0], seesaw.beam_width + 2 * tolerance, atol=1e-3)
+    assert np.isclose(
+        world[4] - world[1], seesaw.beam_length + 2 * tolerance, atol=1e-3
+    )
+
+
+def test_a_cube_beside_the_beam_is_not_in_the_goal_region():
+    """The region is the beam's footprint, not a box loose enough to catch the floor.
+
+    Worth pinning: the region rotates with the seesaw, and a rotation that fell back to
+    an axis-aligned bound would quietly widen it.
+    """
+    env = _get_shipped_balancebeam_env()
+    env.reset(seed=0)
+
+    seesaw = env._objects_dict["seesaw_1"]  # pylint: disable=protected-access
+    assert isinstance(seesaw, GeneratedSeesaw)
+    seesaw_pos, _ = (
+        env._robot_env.get_joint_pos_quat(  # pylint: disable=protected-access
+            seesaw.joint_name
+        )
+    )
+    yaw = _seesaw_yaw(env, seesaw)
+    (region,) = seesaw.region_objects["beam_goal_region"]
+
+    beam_height = seesaw.pivot_height + seesaw.beam_clearance + seesaw.beam_thickness
+
+    def world_point(along: float, across: float) -> NDArray[np.float32]:
+        offset = Rotation.from_euler("z", yaw).apply([along, across, 0.0])
+        return np.array(
+            [
+                seesaw_pos[0] + offset[0],
+                seesaw_pos[1] + offset[1],
+                seesaw_pos[2] + beam_height + 0.015,
+            ],
+            dtype=np.float32,
+        )
+
+    assert region.check_in_region(world_point(0.0, 0.0))
+    assert region.check_in_region(world_point((seesaw.beam_length / 2) * 0.9, 0.0))
+    # Off the side of the beam, and past its end.
+    assert not region.check_in_region(world_point(0.0, seesaw.beam_width))
+    assert not region.check_in_region(world_point(seesaw.beam_length, 0.0))
+    # And lying on the ground beneath the beam is not on the beam.
+    on_the_ground = world_point((seesaw.beam_length / 2) * 0.5, 0.0)
+    on_the_ground[2] = np.float32(seesaw_pos[2] + 0.018)
+    assert not region.check_in_region(on_the_ground)


### PR DESCRIPTION
`BalanceBeam3D-o3`'s goal was `[["balanced", "seesaw_1", 5.0]]` -- the beam within 5 degrees of level, and nothing else. An empty beam already is, so the goal held at reset and **the task was solved by doing nothing**. kinder's own generated docs record it:

> **Random Action Stats**: Total Reward: -1.00, Success: **Yes**, Steps: **1**

The variant description says what was meant: *"Place three cubes onto a seesaw without tipping it past the balance threshold."* Only the second half was ever checked.

Reproduced through the wrapper robocode evaluates with, on every seed:

```
seed 0 zero-action step -> terminated=True  reward=-1.0
seed 1 zero-action step -> terminated=True  reward=-1.0
seed 2 zero-action step -> terminated=True  reward=-1.0
```

Tossing3D, SweepIntoDrawer3D and Obstruction3D all give 0.00 under a random policy, so this is specific to BalanceBeam3D rather than something systemic.

## Stating the task

No new predicate -- the goal DSL already says this. A `beam_goal_region` attached to the seesaw, one `on` atom per cube, conjoined with the balance check:

```json
"beam_goal_region": {
    "target": "seesaw_1",
    "rgba": [0.2, 0.6, 0.2, 0.4]
},
```
```json
"goal_state": [
    "and",
    ["on", "small_block_1", "beam_goal_region"],
    ["on", "small_block_2", "beam_goal_region"],
    ["on", "large_block", "beam_goal_region"],
    ["balanced", "seesaw_1", 5.0]
]
```

Same shape as #166's Tossing3D goal region on `bin_0`. It also inherits region rendering, so the target is visible in the scene instead of implicit.

## The region derives its extents from the seesaw

Note what the region does **not** say: any ranges. A seesaw fills those in from the beam it actually builds, via `GeneratedSeesaw.beam_surface_range()`, so a task never restates `beam_length` or `beam_width` and the region cannot go stale when that geometry changes.

Two choices in it worth flagging:

**The floor sits at the pivot, not at the beam's top surface.** The beam tilts. A cube near the end rides up to `beam_length/2 * sin(5 deg)` = 1.6cm below the level surface at the tolerance this task calls balanced -- more than the 1cm of slack `_create_regions` adds. The pivot is still well clear of anything lying on the ground beside or beneath the beam, and there is a test for that case.

**The ceiling is generous.** Gravity decides what is resting on the beam, so the upper bound only has to exclude something held far above it.

## `is_object_on_beam` was measuring against the world axes

Separately: the helper compared world x against half the beam *length* and world y against half its *width*. This task yaws the seesaw 90 degrees, so the two limits were swapped -- 0.18m of beam judged against a 0.035m half-width, and a cube resting mid-beam read as off it:

```
along=-0.126 -> fixed=True  old(world-axis)=False
along=+0.126 -> fixed=True  old(world-axis)=False
```

It now rotates the offset into the seesaw's frame first. Yaw only, deliberately: folding in the hinge pitch would shrink the footprint a cube has to sit within simply because the beam is not level, which is backwards for a task about loading a beam that tilts.

The helper had **no caller in the repo**. The existing o4 test does reach it through `_assert_block_on_seesaw`, but pins the seesaw to yaw 0, which is why this survived.

## Verification

Five tests, **each checked to fail without the change it covers**:

| test | fails without |
|---|---|
| doing nothing does not solve the shipped task | the goal change |
| cubes placed to balance the beam **do** solve it | goal change + orientation fix |
| the region's extents come from the beam | the derived region |
| a cube beside, past, or under the beam is not in the region | the derived region |
| the beam's extents follow the beam, not world x | the orientation fix |

The second matters as much as the first: tightening a goal is only correct if the task stays achievable, so it places the cubes, settles the physics, and asserts the goal holds.

`400 passed, 4 skipped` across `tests/envs/dynamic3d`; pylint and mypy clean.

## Not included

`docs/envs/BalanceBeam3D.md` and the variant page are generated by `scripts/docs/generate_env_docs.py`, so they are untouched here. Regenerating them will drop the "Success: Yes, Steps: 1" line quoted above.
