### PR TITLE
WIP: drop the redundant mj_forward from the substep loop

### DIFF
--- a/src/kinder/envs/dynamic3d/mujoco_utils.py
+++ b/src/kinder/envs/dynamic3d/mujoco_utils.py
@@ -170,7 +170,13 @@ class MujocoEnv(gymnasium.Env[MjObs, Array]):
 
         for tick in range(num_sim_steps):
             self._update_ctrl(schedule[tick // ticks_per_row])
-            self.sim.forward()
+            # No mj_forward here: mj_step recomputes forward dynamics itself before
+            # integrating, and nothing reads mjData in between, so the extra call is
+            # the whole forward pass done twice. Contact solving dominates the cost,
+            # so dropping it roughly halves the time of a control period. State that
+            # is written directly (joint positions, object poses) still needs an
+            # explicit forward() at the point of the write -- see the call sites in
+            # the robot envs -- because no mj_step follows those.
             self.sim.step()
 
         # Post-action processing

--- a/tests/envs/dynamic3d/test_mujoco_utils.py
+++ b/tests/envs/dynamic3d/test_mujoco_utils.py
@@ -8,6 +8,7 @@ from kinder.envs.dynamic3d.mujoco_utils import (
     CONTROL_SCHEDULE_TIMESTEP,
     SIMULATION_TIMESTEP,
     MjObs,
+    MjSim,
     MujocoEnv,
 )
 
@@ -123,3 +124,47 @@ def test_a_schedule_survives_a_gymnasium_wrapper():
         unwrapped.get_obs()["qpos"], wrapped.unwrapped.get_obs()["qpos"]
     )
     assert len(wrapped.render()) == 1
+
+
+def test_a_control_period_does_not_call_forward_dynamics_twice_per_tick(monkeypatch):
+    """mj_step already runs the forward pass, so the loop must not run it as well.
+
+    Contact solving dominates a control period, and calling forward() before step()
+    pays for it twice. This counts rather than times, so it fails on a slow machine
+    for the right reason instead of flaking. Patched on the class via monkeypatch:
+    binding a counter onto the instance would close over the bound method and leave
+    a reference cycle, which defers the env's teardown into a later test -- and a
+    render context freed at that point takes the process down on macOS.
+    """
+    calls = 0
+    real_forward = MjSim.forward
+
+    def counting_forward(self) -> None:
+        nonlocal calls
+        calls += 1
+        real_forward(self)
+
+    # After make_env, so the forward() that reset legitimately runs is not counted.
+    env = make_env()
+    monkeypatch.setattr(MjSim, "forward", counting_forward)
+    env.step(np.array([0.7]))
+
+    assert calls == 0, f"step() ran mj_forward {calls} times; mj_step already does"
+
+
+def test_dropping_the_per_tick_forward_leaves_the_trajectory_untouched():
+    """The removed call was dead work: nothing reads mjData between it and mj_step.
+
+    Pinned as an equality rather than a tolerance because the claim is that the two
+    loops issue the same MuJoCo calls in the same order, not that they merely agree
+    to within integration error.
+    """
+    stepped, with_forward = make_env(), make_env()
+    action = np.array([0.7])
+
+    stepped.step(action)
+    # replay_ticks still calls forward() before every step(), i.e. the old loop.
+    replay_ticks(with_forward, np.repeat(action[None], TICKS_PER_STEP, axis=0))
+
+    assert np.array_equal(stepped.get_obs()["qpos"], with_forward.get_obs()["qpos"])
+    assert np.array_equal(stepped.get_obs()["qvel"], with_forward.get_obs()["qvel"])


### PR DESCRIPTION
**WIP / draft.** The change and its tests are complete and green; opening early because the performance claim affects every dynamic3d domain and is worth a second pair of eyes before it lands.

## What

`MujocoEnv.step` ran `sim.forward()` before `sim.step()` on every physics tick:

```python
for tick in range(num_sim_steps):
    self._update_ctrl(schedule[tick // ticks_per_row])
    self.sim.forward()   # <- removed
    self.sim.step()
```

`mj_step` already computes forward dynamics before integrating, and nothing reads `mjData` between the two calls, so the forward pass ran twice per tick with one result discarded. At the default control rate that is 200 wasted forward passes per control period.

## Why it is safe

The loop always ends on `step()`, so the `forward()` calls never influenced anything a caller could observe. Comparing the new loop against the old one, `qpos`, `qvel` and `xpos` are **bit-identical** (`0.000e+00`), which the added equality test pins as an exact comparison rather than a tolerance.

Worth noting that hoisting the call to *after* the loop, which I tried first, is the variant that actually changes behaviour (~1e-10 in `xpos`) because it refreshes derived quantities the old code left one substep stale. Deleting is the conservative option here, not the aggressive one.

State that is written directly rather than integrated (joint positions, object poses) still needs its own `forward()`; those call sites in the robot envs are untouched.

## Impact

Profile of ScoopPour3D at 100 objects, 10 control steps:

| call | time | share |
|---|---|---|
| `mj_forward` | 16.8s | 50% |
| `mj_step` | 16.1s | 48% |
| everything else | ~0.6s | <2% |

Contact solving dominates both, so removing one of two equal halves roughly **halves the wall-clock cost of a control period** across every dynamic3d domain. This lands on eval wall-clock budgets and on how much the coding agents can probe within a fixed budget.

## Tests

- `test_a_control_period_does_not_call_forward_dynamics_twice_per_tick` counts rather than times, so it cannot flake on a loaded machine. Against the old code it fails with `ran mj_forward 200 times`, which is exactly the substep count.
- `test_dropping_the_per_tick_forward_leaves_the_trajectory_untouched` compares against `replay_ticks`, which still issues the old `forward()`+`step()` sequence.

`tests/envs/dynamic3d`: **389 passed, 12 skipped**. pylint 10.00/10, mypy clean, black and isort clean.

## One aside

The counter is patched on `MjSim` via pytest's `monkeypatch` rather than onto the instance. Binding it to the instance creates a reference cycle (`sim` -> closure -> `sim`) that defers the env's teardown into a later test, and freeing a MuJoCo render context at that point kills the process on macOS with `Default framebuffer is not complete`. Recorded in the test docstring so it does not get reintroduced.