### PR TITLE
Add KinematicCylinderShelf3D: tall cylinders that require side grasps

### DIFF
--- a/src/kinder/__init__.py
+++ b/src/kinder/__init__.py
@@ -356,6 +356,25 @@ def _register_kinematic3d() -> None:
         variant_ids=variant_ids,
     )
 
+    # KinematicCylinderShelf3D environment.
+    num_cylinders = [1, 2, 3]
+    variant_ids = []
+    for num_cylinder in num_cylinders:
+        variant_id = f"kinder/KinematicCylinderShelf3D-o{num_cylinder}-v0"
+        _register(
+            id=variant_id,
+            entry_point="kinder.envs.kinematic3d.cylinder_shelf3d:CylinderShelf3DEnv",
+            kwargs={"num_cylinders": num_cylinder},
+        )
+        variant_ids.append(variant_id)
+    _register_env_class(
+        class_name="KinematicCylinderShelf3D",
+        entry_point="kinder.envs.kinematic3d.cylinder_shelf3d:CylinderShelf3DEnv",
+        category="Kinematic3D",
+        backend="pybullet",
+        variant_ids=variant_ids,
+    )
+
     # PrplLab3D environment.
     num_cubes = [1, 2]
     variant_ids = []

--- a/src/kinder/envs/kinematic3d/cylinder_shelf3d.py
+++ b/src/kinder/envs/kinematic3d/cylinder_shelf3d.py
@@ -1,0 +1,317 @@
+"""PyBullet environment where tall cylinders must be picked from the ground and placed
+on a shelf.
+
+The cylinders are tall enough that a side grasp (horizontal approach) is required rather
+than a top grasp. Because cylinders are rotationally symmetric, any horizontal approach
+angle is a valid grasp direction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from typing import Type as TypingType
+
+import pybullet as p
+from pybullet_helpers.geometry import Pose, get_pose, set_pose
+from pybullet_helpers.utils import create_pybullet_cylinder, create_pybullet_shelf
+from relational_structs import Object, ObjectCentricState
+from relational_structs.utils import create_state_from_dict
+
+from kinder.core import ConstantObjectKinDEREnv, FinalConfigMeta
+from kinder.envs.kinematic3d.base_env import (
+    Kinematic3DEnvConfig,
+    ObjectCentricKinematic3DRobotEnv,
+)
+from kinder.envs.kinematic3d.object_types import (
+    Kinematic3DCuboidType,
+    Kinematic3DEnvTypeFeatures,
+    Kinematic3DFixtureType,
+    Kinematic3DRobotType,
+)
+from kinder.envs.kinematic3d.utils import (
+    Kinematic3DObjectCentricState,
+    sample_collision_free_object_poses,
+)
+
+# The "object_type" feature value for cylinders. Cuboids use -1.0 (see
+# ObjectCentricKinematic3DRobotEnv._create_state_dict).
+CYLINDER_OBJECT_TYPE = 1.0
+
+
+@dataclass(frozen=True)
+class CylinderShelf3DEnvConfig(Kinematic3DEnvConfig, metaclass=FinalConfigMeta):
+    """Config for CylinderShelf3DEnv()."""
+
+    max_action_mag: float = 0.2
+
+    # Shelf.
+    shelf_pose: Pose = Pose((2.0, 2.4, 0.02))
+    shelf_rgba: tuple[float, float, float, float] = (0.5, 0.5, 0.5, 1.0)
+    shelf_width: float = 0.60198
+    shelf_depth: float = 0.254
+    shelf_height: float = 0.0127
+    shelf_spacing: float = 0.254
+    shelf_support_width: float = 0.0127
+    shelf_num_layers: int = 4
+    shelf_texture: Path = Path(__file__).parent / "assets" / "dark-wood-texture.png"
+
+    # World bounds.
+    x_lb: float = -1.0
+    x_ub: float = 1.0
+    y_lb: float = -1.0
+    y_ub: float = 1.0
+
+    # Cylinders. Heights are cycled by cylinder index, so multi-object
+    # variants get cylinders of different heights. All heights should stay
+    # comfortably below shelf_spacing so a placed cylinder fits between
+    # shelf layers.
+    cylinder_radius: float = 0.03
+    cylinder_heights: tuple[float, ...] = (0.20, 0.15, 0.175)
+    cylinder_rgbas: tuple[tuple[float, float, float, float], ...] = (
+        (0.8, 0.2, 0.2, 1.0),
+        (0.2, 0.5, 0.8, 1.0),
+        (0.2, 0.7, 0.3, 1.0),
+        (0.8, 0.6, 0.2, 1.0),
+        (0.6, 0.3, 0.7, 1.0),
+    )
+
+    # Gripper.
+    gripper_open_threshold: float = 0.01
+
+    # Goal checking: tolerance below the first shelf layer for determining if
+    # a cylinder is "on the shelf". Cylinders must be above (shelf_pose.z +
+    # shelf_spacing - on_shelf_z_tolerance) to count as placed.
+    on_shelf_z_tolerance: float = 0.05
+
+    def get_camera_kwargs(self) -> dict[str, Any]:
+        """Get kwargs to pass to PyBullet camera."""
+        return {
+            "camera_target": (0, 0, 0),
+            "camera_yaw": 0,
+            "camera_distance": 2.0,
+            "camera_pitch": -20,
+        }
+
+    def get_cylinder_height(self, idx: int) -> float:
+        """Get the height of the cylinder with the given index."""
+        return self.cylinder_heights[idx % len(self.cylinder_heights)]
+
+    def get_cylinder_rgba(self, idx: int) -> tuple[float, float, float, float]:
+        """Get the color of the cylinder with the given index."""
+        return self.cylinder_rgbas[idx % len(self.cylinder_rgbas)]
+
+
+class CylinderShelf3DObjectCentricState(Kinematic3DObjectCentricState):
+    """A state in the CylinderShelf3DEnv().
+
+    Adds convenience methods on top of Kinematic3DObjectCentricState().
+    """
+
+
+class ObjectCentricCylinderShelf3DEnv(
+    ObjectCentricKinematic3DRobotEnv[
+        Kinematic3DObjectCentricState, CylinderShelf3DEnvConfig
+    ]
+):
+    """PyBullet environment where tall cylinders must be picked from the ground and
+    placed on a shelf."""
+
+    def __init__(
+        self,
+        num_cylinders: int = 1,
+        config: CylinderShelf3DEnvConfig = CylinderShelf3DEnvConfig(),
+        **kwargs,
+    ) -> None:
+        super().__init__(config=config, **kwargs)
+        self._num_cylinders = num_cylinders
+
+        # Create the cylinders, but their poses will be reset (with collision
+        # checking) in the reset() method.
+        self._cylinders: dict[str, int] = {}
+        for idx in range(self._num_cylinders):
+            cylinder_id = create_pybullet_cylinder(
+                self.config.get_cylinder_rgba(idx),
+                self.config.cylinder_radius,
+                self.config.get_cylinder_height(idx),
+                physics_client_id=self.physics_client_id,
+            )
+            self._cylinders[f"cylinder{idx}"] = cylinder_id
+
+        # Create shelf.
+        self._shelf_id, self._shelf_surface_ids = create_pybullet_shelf(
+            color=self.config.shelf_rgba,
+            shelf_width=self.config.shelf_width,
+            shelf_depth=self.config.shelf_depth,
+            shelf_height=self.config.shelf_height,
+            spacing=self.config.shelf_spacing,
+            support_width=self.config.shelf_support_width,
+            num_layers=self.config.shelf_num_layers,
+            physics_client_id=self.physics_client_id,
+        )
+        set_pose(self._shelf_id, self.config.shelf_pose, self.physics_client_id)
+
+        shelf_texture_id = p.loadTexture(
+            str(self.config.shelf_texture), self.physics_client_id
+        )
+        for shelf_link_id in range(
+            p.getNumJoints(self._shelf_id, physicsClientId=self.physics_client_id)
+        ):
+            p.changeVisualShape(
+                self._shelf_id,
+                shelf_link_id,
+                textureUniqueId=shelf_texture_id,
+                physicsClientId=self.physics_client_id,
+            )
+
+    @property
+    def state_cls(self) -> TypingType[Kinematic3DObjectCentricState]:
+        return CylinderShelf3DObjectCentricState
+
+    def _create_constant_initial_state_dict(self) -> dict[Object, dict[str, float]]:
+        return self._create_state_dict([("shelf", Kinematic3DFixtureType)])
+
+    def _reset_objects(self) -> None:
+        # Sample one cylinder at a time because each has its own height, and
+        # therefore its own resting z. The sampler adds each placed cylinder
+        # to the collision set for the next one.
+        placed_ids: set[int] = {self.robot.base.robot_id}
+        for idx in range(self._num_cylinders):
+            cylinder_id = self._cylinders[f"cylinder{idx}"]
+            half_height = self.config.get_cylinder_height(idx) / 2
+            sample_collision_free_object_poses(
+                object_ids={cylinder_id},
+                lb=(self.config.x_lb, self.config.y_lb, half_height),
+                ub=(self.config.x_ub, self.config.y_ub, half_height),
+                physics_client_id=self.physics_client_id,
+                rng=self.np_random,
+                other_collision_ids=placed_ids,
+            )
+            placed_ids.add(cylinder_id)
+
+    def _set_object_states(self, obs: Kinematic3DObjectCentricState) -> None:
+        assert isinstance(obs, CylinderShelf3DObjectCentricState)
+        for cylinder_name, cylinder_id in self._cylinders.items():
+            assert cylinder_id is not None
+            set_pose(
+                cylinder_id,
+                obs.get_object_pose(cylinder_name),
+                self.physics_client_id,
+            )
+
+    def _object_name_to_pybullet_id(self, object_name: str) -> int:
+        if object_name == "shelf":
+            return self._shelf_id
+        if object_name.startswith("cylinder"):
+            return self._cylinders[object_name]
+        raise ValueError(f"Unrecognized object name: {object_name}")
+
+    def _get_collision_object_ids(self) -> set[int]:
+        collision_ids = {self._shelf_id} | set(self._cylinders.values())
+        return collision_ids
+
+    def _get_movable_object_names(self) -> set[str]:
+        return set(self._cylinders.keys())
+
+    def _get_surface_object_names(self) -> set[str]:
+        return {"shelf"}
+
+    def _get_half_extents(self, object_name: str) -> tuple[float, float, float]:
+        if object_name.startswith("cylinder"):
+            idx = int(object_name[len("cylinder") :])
+            return (
+                self.config.cylinder_radius,
+                self.config.cylinder_radius,
+                self.config.get_cylinder_height(idx) / 2,
+            )
+        raise ValueError(f"Unrecognized object name: {object_name}")
+
+    def _get_obs(self) -> CylinderShelf3DObjectCentricState:
+        state_dict = self._create_state_dict(
+            [("robot", Kinematic3DRobotType)]
+            + [("shelf", Kinematic3DFixtureType)]
+            + [
+                ("cylinder" + str(i), Kinematic3DCuboidType)
+                for i in range(self._num_cylinders)
+            ]
+        )
+        state = create_state_from_dict(
+            state_dict,
+            Kinematic3DEnvTypeFeatures,
+            state_cls=CylinderShelf3DObjectCentricState,
+        )
+        assert isinstance(state, CylinderShelf3DObjectCentricState)
+        # The generic cuboid serializer tags every Kinematic3DCuboidType
+        # object as a cuboid; re-tag the cylinders.
+        for cylinder_name in self._cylinders:
+            obj = state.get_object_from_name(cylinder_name)
+            state.set(obj, "object_type", CYLINDER_OBJECT_TYPE)
+        return state
+
+    def goal_reached(self) -> bool:
+        robot_gripper_pose = self._robot_arm.get_finger_state()
+        if robot_gripper_pose > self.config.gripper_open_threshold:
+            return False
+        # Check that all cylinders are above the first shelf layer (with
+        # tolerance).
+        min_on_shelf_z = (
+            self.config.shelf_pose.position[2]
+            + self.config.shelf_spacing
+            - self.config.on_shelf_z_tolerance
+        )
+        for _, cylinder_id in self._cylinders.items():
+            cylinder_pose = get_pose(cylinder_id, self.physics_client_id)
+            if cylinder_pose.position[2] < min_on_shelf_z:
+                return False
+
+        return True
+
+
+class CylinderShelf3DEnv(ConstantObjectKinDEREnv):
+    """Cylinder shelf 3D env with a constant number of objects."""
+
+    def __init__(self, num_cylinders: int = 1, **kwargs) -> None:
+        self._num_cylinders = num_cylinders
+        super().__init__(num_cylinders=num_cylinders, **kwargs)
+
+    def _create_object_centric_env(
+        self, *args, **kwargs
+    ) -> ObjectCentricKinematic3DRobotEnv:
+        return ObjectCentricCylinderShelf3DEnv(*args, **kwargs)
+
+    def _get_constant_object_names(
+        self, exemplar_state: ObjectCentricState
+    ) -> list[str]:
+        constant_objects = ["robot", "shelf"]
+        for obj in exemplar_state:
+            if obj.name.startswith("cylinder"):
+                constant_objects.append(obj.name)
+        return constant_objects
+
+    def _create_env_markdown_description(self) -> str:
+        """Create environment description."""
+        # pylint: disable=line-too-long
+        return """A 3D environment where the goal is to pick up tall cylinders from the ground and place them onto a shelf. The cylinders are tall enough that they must be grasped from the side rather than from the top."""
+
+    def _create_variant_markdown_description(self) -> str:
+        # pylint: disable=line-too-long
+        return "The number of cylinders differs between environment variants. For example, CylinderShelf3D-o1 has 1 cylinder, while CylinderShelf3D-o3 has 3 cylinders of different heights."
+
+    def _create_variant_specific_description(self) -> str:
+        if self._num_cylinders == 1:
+            return "This variant has 1 cylinder to place on the shelf."
+        return (
+            f"This variant has {self._num_cylinders} cylinders of different "
+            "heights to place on the shelf."
+        )
+
+    def _create_reward_markdown_description(self) -> str:
+        """Create reward description."""
+        # pylint: disable=line-too-long
+        return """The reward is -1 per timestep to encourage efficient task completion. The episode terminates successfully when all cylinders are placed on the shelf (i.e., above the first shelf layer) and the gripper is closed. The gripper must be closed to prevent accidental "success" while a cylinder is still being held above the shelf."""
+
+    def _create_references_markdown_description(self) -> str:
+        """Create references description."""
+        # pylint: disable=line-too-long
+        return """This is a very common kind of environment. The background is adapted from the [Replica dataset](https://arxiv.org/abs/1906.05797) (Straub et al., 2019)."""

--- a/tests/envs/kinematic3d/test_cylinder_shelf3d.py
+++ b/tests/envs/kinematic3d/test_cylinder_shelf3d.py
@@ -1,0 +1,184 @@
+"""Tests for cylinder_shelf3d.py."""
+
+# pylint: disable=protected-access
+
+import numpy as np
+import pytest
+from pybullet_helpers.geometry import Pose, SE2Pose
+from pybullet_helpers.inverse_kinematics import inverse_kinematics
+from pybullet_helpers.joint import get_jointwise_difference
+from scipy.spatial.transform import Rotation
+
+from kinder.envs.kinematic3d.cylinder_shelf3d import (
+    CYLINDER_OBJECT_TYPE,
+    CylinderShelf3DEnv,
+    ObjectCentricCylinderShelf3DEnv,
+)
+
+
+@pytest.fixture(scope="module")
+def env():
+    """Create a shared object-centric environment for tests in this module."""
+    environment = ObjectCentricCylinderShelf3DEnv(
+        num_cylinders=2,
+        use_gui=False,
+        realistic_bg=False,
+    )
+    yield environment
+    environment.close()
+
+
+def test_cylinder_shelf3d_env(env):  # pylint: disable=redefined-outer-name
+    """Basic reset / step / observation checks."""
+    obs, _ = env.reset(seed=123)
+
+    # Cylinders have per-index heights, cycled from the config, and are
+    # tagged as cylinders in the state.
+    for idx in range(2):
+        obj = obs.get_object_from_name(f"cylinder{idx}")
+        expected_half_height = env.config.get_cylinder_height(idx) / 2
+        assert np.isclose(obs.get(obj, "half_extent_z"), expected_half_height)
+        assert np.isclose(obs.get(obj, "half_extent_x"), env.config.cylinder_radius)
+        assert np.isclose(obs.get(obj, "object_type"), CYLINDER_OBJECT_TYPE)
+        # Resting on the ground.
+        assert np.isclose(obs.get(obj, "pose_z"), expected_half_height)
+
+    for _ in range(5):
+        act = env.action_space.sample()
+        obs, _, _, _, _ = env.step(act)
+
+
+def test_cylinder_shelf3d_gym_registration():
+    """The gym-registered variants construct and reset."""
+    # pylint: disable=import-outside-toplevel
+    import kinder
+
+    kinder.register_all_environments()
+    gym_env = kinder.make("kinder/KinematicCylinderShelf3D-o1-v0", realistic_bg=False)
+    obs, _ = gym_env.reset(seed=0)
+    assert isinstance(obs, np.ndarray)
+    gym_env.close()
+
+
+def _side_grasp_orientation(
+    approach_yaw: float, approach_pitch: float = np.deg2rad(15)
+) -> tuple[float, ...]:
+    """End-effector orientation for a (near-)horizontal side grasp.
+
+    Tool z (the approach axis) points along `approach_yaw`, tilted down by
+    `approach_pitch`; tool x (the finger-closing axis) is horizontal and
+    perpendicular to the approach, so the fingers straddle a vertical
+    cylinder. The slight downward pitch widens the arm's reachable
+    envelope at low grasp heights.
+    """
+    approach = np.array(
+        [
+            np.cos(approach_yaw) * np.cos(approach_pitch),
+            np.sin(approach_yaw) * np.cos(approach_pitch),
+            -np.sin(approach_pitch),
+        ]
+    )
+    perp = np.array([-np.sin(approach_yaw), np.cos(approach_yaw), 0.0])
+    rot_matrix = np.column_stack([perp, np.cross(approach, perp), approach])
+    return tuple(Rotation.from_matrix(rot_matrix).as_quat())
+
+
+def _drive_arm_to_joints(environment, obs, target_joints, max_steps=200, step_mag=0.05):
+    """Step the env along the joint-space line to the target.
+
+    The delta is scaled uniformly (rather than clipped per-joint) so the executed path
+    follows the straight joint-space line between IK solutions. Stops early if a
+    collision revert blocks progress; callers check the resulting state.
+    """
+    joint_infos = environment.robot.arm.get_arm_joint_infos()[:7]
+    for _ in range(max_steps):
+        delta = np.array(
+            get_jointwise_difference(
+                joint_infos, target_joints[:7], obs.joint_positions
+            )
+        )
+        max_abs = np.max(np.abs(delta))
+        if max_abs < 1e-4:
+            return obs
+        previous = np.array(obs.joint_positions)
+        scaled = delta * min(1.0, step_mag / max_abs)
+        action = np.array([0.0] * 3 + list(scaled) + [0.0], dtype=np.float32)
+        obs, _, _, _, _ = environment.step(action)
+        if np.allclose(previous, obs.joint_positions):
+            # Collision revert; no further progress possible.
+            return obs
+    return obs
+
+
+def test_side_grasp(env):  # pylint: disable=redefined-outer-name
+    """A horizontal side grasp near the cylinder top succeeds."""
+    obs, _ = env.reset(seed=123)
+
+    cylinder_pose = obs.get_object_pose("cylinder0")
+    cx, cy, _ = cylinder_pose.position
+    height = env.config.get_cylinder_height(0)
+
+    # Drive the base to face the cylinder from 0.6 m away, in steps bounded
+    # by the action magnitude limit.
+    approach_yaw = np.arctan2(cy, cx)
+    target_base = SE2Pose(
+        cx - 0.6 * np.cos(approach_yaw),
+        cy - 0.6 * np.sin(approach_yaw),
+        approach_yaw,
+    )
+    for _ in range(100):
+        delta = target_base - obs.base_pose
+        coords = [delta.x, delta.y, delta.rot]
+        if np.max(np.abs(coords)) < 1e-4:
+            break
+        coords = np.clip(coords, -env.config.max_action_mag, env.config.max_action_mag)
+        action = np.array(list(coords) + [0.0] * 7 + [0.0], dtype=np.float32)
+        obs, _, _, _, _ = env.step(action)
+
+    # Side grasp near the top of the cylinder, approached along the (slightly
+    # pitched) approach axis. The end effector stops 2 cm short of the
+    # cylinder axis so the fingers straddle the cylinder without contact,
+    # while the grasp-detection zone still overlaps it.
+    orientation = _side_grasp_orientation(approach_yaw)
+    pitch = np.deg2rad(15)
+    approach = np.array(
+        [
+            np.cos(approach_yaw) * np.cos(pitch),
+            np.sin(approach_yaw) * np.cos(pitch),
+            -np.sin(pitch),
+        ]
+    )
+    axis_point = np.array([cx, cy, height - 0.05])
+    grasp = Pose(tuple(axis_point - 0.02 * approach), orientation)
+    pre_grasp = Pose(tuple(axis_point - 0.12 * approach), orientation)
+
+    pre_grasp_joints = inverse_kinematics(
+        env.robot.arm, pre_grasp, validate=True, set_joints=False
+    )
+    obs = _drive_arm_to_joints(env, obs, pre_grasp_joints)
+    grasp_joints = inverse_kinematics(
+        env.robot.arm, grasp, validate=True, set_joints=False
+    )
+    obs = _drive_arm_to_joints(env, obs, grasp_joints)
+
+    # Close the gripper.
+    for _ in range(5):
+        action = np.array([0.0] * 10 + [-1.0], dtype=np.float32)
+        obs, _, _, _, _ = env.step(action)
+    assert obs.grasped_object == "cylinder0"
+
+    # Retract; the cylinder comes along.
+    obs = _drive_arm_to_joints(env, obs, env.config.initial_joints)
+    assert obs.grasped_object == "cylinder0"
+    obj = obs.get_object_from_name("cylinder0")
+    assert obs.get(obj, "pose_z") > 0.3
+
+
+def test_gym_env_wrapper():
+    """The ConstantObjectKinDEREnv wrapper vectorizes and devectorizes."""
+    gym_env = CylinderShelf3DEnv(num_cylinders=1, realistic_bg=False)
+    vec_obs, _ = gym_env.reset(seed=42)
+    state = gym_env.observation_space.devectorize(vec_obs)
+    assert state.get_object_from_name("cylinder0") is not None
+    assert state.get_object_from_name("shelf") is not None
+    gym_env.close()


### PR DESCRIPTION
## Summary

Adds `KinematicCylinderShelf3D`, a kinematic3d environment mirroring `KinematicShelf3D` but with cylinders of different heights instead of cubes. The cylinders are tall enough (0.15-0.20 m, cycled per index) that a top grasp is not viable: they are meant to be grasped from the side, and being rotationally symmetric, from any approach angle. Registered as `kinder/KinematicCylinderShelf3D-o{1,2,3}-v0`.

- `CylinderShelf3DEnvConfig` carries the same shelf geometry as `Shelf3DEnvConfig` plus per-index cylinder heights/colors; cylinders are tagged in the state via the `object_type` feature (`1.0`, vs `-1.0` for cuboids).
- Initial poses are sampled one cylinder at a time because each height implies its own resting z.
- Goal check matches Shelf3D: all cylinders above the first shelf layer with the gripper closed.

## Testing

- `tests/envs/kinematic3d/test_cylinder_shelf3d.py` covers reset/step/observation features, gym registration, the vectorizing wrapper, and a scripted side grasp (near-horizontal approach with a 15° downward pitch, fingers straddling the cylinder): navigate, reach, close, and retract with the cylinder in hand.
- Full local CI (`run_ci_checks.sh`) passes apart from pre-existing pylint failures in unrelated dynamic3d tests.

Companion PRs: skills + bilevel-planning models in kinder-baselines, and the pipeline config in prpl-tidybot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
