### PR TITLE
Support shelves with omitted boards in CylinderShelf3D

### DIFF
--- a/src/kinder/envs/kinematic3d/cylinder_shelf3d.py
+++ b/src/kinder/envs/kinematic3d/cylinder_shelf3d.py
@@ -15,7 +15,7 @@ from typing import Type as TypingType
 
 import pybullet as p
 from pybullet_helpers.geometry import Pose, get_pose, set_pose
-from pybullet_helpers.utils import create_pybullet_cylinder, create_pybullet_shelf
+from pybullet_helpers.utils import create_pybullet_cylinder
 from relational_structs import Object, ObjectCentricState
 from relational_structs.utils import create_state_from_dict
 
@@ -55,6 +55,11 @@ class CylinderShelf3DEnvConfig(Kinematic3DEnvConfig, metaclass=FinalConfigMeta):
     shelf_spacing: float = 0.254
     shelf_support_width: float = 0.0127
     shelf_num_layers: int = 4
+    # Board indices absent from the physical shelf. Removing an inner board
+    # merges the openings around it — e.g. (1,) models a shelf whose bottom
+    # inner board was taken out, leaving one tall opening above the bottom
+    # board for objects taller than the board spacing.
+    shelf_omitted_layers: tuple[int, ...] = ()
     shelf_texture: Path = Path(__file__).parent / "assets" / "dark-wood-texture.png"
 
     # World bounds.
@@ -80,9 +85,9 @@ class CylinderShelf3DEnvConfig(Kinematic3DEnvConfig, metaclass=FinalConfigMeta):
     # Gripper.
     gripper_open_threshold: float = 0.01
 
-    # Goal checking: tolerance below the first shelf layer for determining if
-    # a cylinder is "on the shelf". Cylinders must be above (shelf_pose.z +
-    # shelf_spacing - on_shelf_z_tolerance) to count as placed.
+    # Goal checking: a cylinder counts as placed when it stands within the
+    # shelf footprint with its resting height within this tolerance of some
+    # present board's surface.
     on_shelf_z_tolerance: float = 0.05
 
     def get_camera_kwargs(self) -> dict[str, Any]:
@@ -98,9 +103,135 @@ class CylinderShelf3DEnvConfig(Kinematic3DEnvConfig, metaclass=FinalConfigMeta):
         """Get the height of the cylinder with the given index."""
         return self.cylinder_heights[idx % len(self.cylinder_heights)]
 
+    def get_present_layer_indices(self) -> list[int]:
+        """Indices of the boards actually present on the shelf."""
+        return [
+            i
+            for i in range(self.shelf_num_layers)
+            if i not in self.shelf_omitted_layers
+        ]
+
+    def get_layer_surface_zs(self) -> list[float]:
+        """World-frame z of each present board's top surface, ascending."""
+        return [
+            self.shelf_pose.position[2]
+            + i * (self.shelf_spacing + self.shelf_height)
+            + self.shelf_height / 2
+            for i in self.get_present_layer_indices()
+        ]
+
+    def get_layer_openings(self) -> list[tuple[float, float]]:
+        """Per present board: (surface z, clear height above it).
+
+        The clear height runs to the underside of the next present board, or
+        infinity for the topmost board.
+        """
+        surface_zs = self.get_layer_surface_zs()
+        openings = []
+        for k, surface_z in enumerate(surface_zs):
+            if k + 1 < len(surface_zs):
+                clearance = surface_zs[k + 1] - self.shelf_height - surface_z
+            else:
+                clearance = float("inf")
+            openings.append((surface_z, clearance))
+        return openings
+
     def get_cylinder_rgba(self, idx: int) -> tuple[float, float, float, float]:
         """Get the color of the cylinder with the given index."""
         return self.cylinder_rgbas[idx % len(self.cylinder_rgbas)]
+
+
+def _create_shelf_with_omitted_layers(
+    config: CylinderShelf3DEnvConfig, physics_client_id: int
+) -> tuple[int, set[int]]:
+    """Build the shelf multibody, skipping the omitted board indices.
+
+    Adapted from pybullet_helpers' create_pybullet_shelf, which only builds evenly
+    spaced boards; the side supports still span the full height so the frame matches a
+    shelf whose inner board was physically removed.
+    """
+    collision_shape_ids = []
+    visual_shape_ids = []
+    link_positions = []
+
+    present_layers = config.get_present_layer_indices()
+    for i in present_layers:
+        layer_z = i * (config.shelf_spacing + config.shelf_height)
+        half_extents = [
+            config.shelf_width / 2,
+            config.shelf_depth / 2,
+            config.shelf_height / 2,
+        ]
+        collision_shape_ids.append(
+            p.createCollisionShape(
+                p.GEOM_BOX,
+                halfExtents=half_extents,
+                physicsClientId=physics_client_id,
+            )
+        )
+        visual_shape_ids.append(
+            p.createVisualShape(
+                p.GEOM_BOX,
+                halfExtents=half_extents,
+                rgbaColor=config.shelf_rgba,
+                physicsClientId=physics_client_id,
+            )
+        )
+        link_positions.append([0, 0, layer_z])
+
+    shelf_link_ids = set(range(len(present_layers)))
+
+    support_height = (
+        config.shelf_num_layers - 1
+    ) * config.shelf_spacing + config.shelf_num_layers * config.shelf_height
+    support_half_height = support_height / 2
+    for x_offset in [
+        -config.shelf_width / 2 - config.shelf_support_width / 2,
+        config.shelf_width / 2 + config.shelf_support_width / 2,
+    ]:
+        half_extents = [
+            config.shelf_support_width / 2,
+            config.shelf_depth / 2,
+            support_half_height,
+        ]
+        collision_shape_ids.append(
+            p.createCollisionShape(
+                p.GEOM_BOX,
+                halfExtents=half_extents,
+                physicsClientId=physics_client_id,
+            )
+        )
+        visual_shape_ids.append(
+            p.createVisualShape(
+                p.GEOM_BOX,
+                halfExtents=half_extents,
+                rgbaColor=config.shelf_rgba,
+                physicsClientId=physics_client_id,
+            )
+        )
+        link_positions.append(
+            [x_offset, 0, support_half_height - config.shelf_height / 2]
+        )
+
+    num_links = len(collision_shape_ids)
+    shelf_id = p.createMultiBody(
+        baseMass=0,
+        baseCollisionShapeIndex=-1,
+        baseVisualShapeIndex=-1,
+        basePosition=(0, 0, 0),  # set externally
+        linkMasses=[0] * num_links,
+        linkCollisionShapeIndices=collision_shape_ids,
+        linkVisualShapeIndices=visual_shape_ids,
+        linkPositions=link_positions,
+        linkOrientations=[[0, 0, 0, 1]] * num_links,
+        linkInertialFramePositions=[[0, 0, 0]] * num_links,
+        linkInertialFrameOrientations=[[0, 0, 0, 1]] * num_links,
+        linkParentIndices=[0] * num_links,
+        linkJointTypes=[p.JOINT_FIXED] * num_links,
+        linkJointAxis=[[0, 0, 0]] * num_links,
+        physicsClientId=physics_client_id,
+    )
+    return shelf_id, shelf_link_ids
 
 
 class CylinderShelf3DObjectCentricState(Kinematic3DObjectCentricState):
@@ -140,15 +271,8 @@ class ObjectCentricCylinderShelf3DEnv(
             self._cylinders[f"cylinder{idx}"] = cylinder_id
 
         # Create shelf.
-        self._shelf_id, self._shelf_surface_ids = create_pybullet_shelf(
-            color=self.config.shelf_rgba,
-            shelf_width=self.config.shelf_width,
-            shelf_depth=self.config.shelf_depth,
-            shelf_height=self.config.shelf_height,
-            spacing=self.config.shelf_spacing,
-            support_width=self.config.shelf_support_width,
-            num_layers=self.config.shelf_num_layers,
-            physics_client_id=self.physics_client_id,
+        self._shelf_id, self._shelf_surface_ids = _create_shelf_with_omitted_layers(
+            self.config, self.physics_client_id
         )
         set_pose(self._shelf_id, self.config.shelf_pose, self.physics_client_id)
 
@@ -253,16 +377,25 @@ class ObjectCentricCylinderShelf3DEnv(
         robot_gripper_pose = self._robot_arm.get_finger_state()
         if robot_gripper_pose > self.config.gripper_open_threshold:
             return False
-        # Check that all cylinders are above the first shelf layer (with
-        # tolerance).
-        min_on_shelf_z = (
-            self.config.shelf_pose.position[2]
-            + self.config.shelf_spacing
-            - self.config.on_shelf_z_tolerance
-        )
-        for _, cylinder_id in self._cylinders.items():
+        # Check that every cylinder stands within the shelf footprint with
+        # its center at resting height on some present board.
+        shelf_x, shelf_y, _ = self.config.shelf_pose.position
+        surface_zs = self.config.get_layer_surface_zs()
+        for idx, (_, cylinder_id) in enumerate(sorted(self._cylinders.items())):
             cylinder_pose = get_pose(cylinder_id, self.physics_client_id)
-            if cylinder_pose.position[2] < min_on_shelf_z:
+            x, y, z = cylinder_pose.position
+            if abs(x - shelf_x) > self.config.shelf_width / 2:
+                return False
+            if abs(y - shelf_y) > self.config.shelf_depth / 2:
+                return False
+            resting_z_options = [
+                surface_z + self.config.get_cylinder_height(idx) / 2
+                for surface_z in surface_zs
+            ]
+            if not any(
+                abs(z - resting_z) <= self.config.on_shelf_z_tolerance
+                for resting_z in resting_z_options
+            ):
                 return False
 
         return True
@@ -309,7 +442,7 @@ class CylinderShelf3DEnv(ConstantObjectKinDEREnv):
     def _create_reward_markdown_description(self) -> str:
         """Create reward description."""
         # pylint: disable=line-too-long
-        return """The reward is -1 per timestep to encourage efficient task completion. The episode terminates successfully when all cylinders are placed on the shelf (i.e., above the first shelf layer) and the gripper is closed. The gripper must be closed to prevent accidental "success" while a cylinder is still being held above the shelf."""
+        return """The reward is -1 per timestep to encourage efficient task completion. The episode terminates successfully when all cylinders stand within the shelf footprint at resting height on one of the shelf boards and the gripper is closed. The gripper must be closed to prevent accidental "success" while a cylinder is still being held above the shelf."""
 
     def _create_references_markdown_description(self) -> str:
         """Create references description."""

--- a/tests/envs/kinematic3d/test_cylinder_shelf3d.py
+++ b/tests/envs/kinematic3d/test_cylinder_shelf3d.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 import pytest
-from pybullet_helpers.geometry import Pose, SE2Pose
+from pybullet_helpers.geometry import Pose, SE2Pose, set_pose
 from pybullet_helpers.inverse_kinematics import inverse_kinematics
 from pybullet_helpers.joint import get_jointwise_difference
 from scipy.spatial.transform import Rotation
@@ -12,6 +12,7 @@ from scipy.spatial.transform import Rotation
 from kinder.envs.kinematic3d.cylinder_shelf3d import (
     CYLINDER_OBJECT_TYPE,
     CylinderShelf3DEnv,
+    CylinderShelf3DEnvConfig,
     ObjectCentricCylinderShelf3DEnv,
 )
 
@@ -182,3 +183,42 @@ def test_gym_env_wrapper():
     assert state.get_object_from_name("cylinder0") is not None
     assert state.get_object_from_name("shelf") is not None
     gym_env.close()
+
+
+def test_omitted_layers_shelf_and_goal():
+    """A shelf with the bottom inner board removed has one tall opening, and a cylinder
+    standing on the bottom board inside the footprint reaches the goal."""
+    config = CylinderShelf3DEnvConfig(
+        shelf_omitted_layers=(1,),
+        cylinder_heights=(0.233,),
+        cylinder_radius=0.039,
+    )
+    assert config.get_present_layer_indices() == [0, 2, 3]
+    openings = config.get_layer_openings()
+    # The bottom opening spans up to the second present board.
+    assert openings[0][1] == pytest.approx(
+        2 * (config.shelf_spacing + config.shelf_height) - config.shelf_height
+    )
+    assert openings[-1][1] == float("inf")
+
+    environment = ObjectCentricCylinderShelf3DEnv(
+        num_cylinders=1, config=config, realistic_bg=False
+    )
+    environment.reset(seed=0)
+    # Stand the cylinder on the bottom board, inside the footprint.
+    shelf_x, shelf_y, _ = config.shelf_pose.position
+    resting_z = config.get_layer_surface_zs()[0] + 0.233 / 2
+    set_pose(
+        environment._cylinders["cylinder0"],
+        Pose((shelf_x, shelf_y, resting_z)),
+        environment.physics_client_id,
+    )
+    assert environment.goal_reached()
+    # On the floor next to the shelf: not a goal state.
+    set_pose(
+        environment._cylinders["cylinder0"],
+        Pose((shelf_x, shelf_y - 1.0, 0.233 / 2)),
+        environment.physics_client_id,
+    )
+    assert not environment.goal_reached()
+    environment.close()


### PR DESCRIPTION
## Summary

Supports shelves with missing boards in `CylinderShelf3D`, mirroring our physical staging: the real shelf's bottom inner board is removed, leaving one tall opening above the bottom board for objects taller than a regular board gap (a Pringles can, 233 mm vs the 241 mm gap).

- `shelf_omitted_layers` (default `()`, fully backward-compatible) lists absent board indices; the shelf multibody is built locally with those boards skipped and the side supports still spanning full height.
- The goal check changes from "above the first shelf layer" to "standing within the shelf footprint at resting height on some present board", covering placements on the bottom board inside a merged opening.
- Config helpers expose the present boards' surface heights and the clear opening above each, for consumers that choose a placement board (used by the kinder-baselines place skill).

## Testing

- New test builds the `(1,)`-omitted shelf, checks board indices/openings, and verifies the goal fires for a can standing on the bottom board (and not for one on the floor beside the shelf).
- Full local CI passes apart from the two pre-existing pylint warnings in unrelated dynamic3d/obstruction3d tests.

Companion PRs follow in kinder-baselines (opening-based placement) and prpl-tidybot (Pringles staging config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
